### PR TITLE
PR#5 (Add support for Travis-CI)

### DIFF
--- a/.prettyci.composer.json
+++ b/.prettyci.composer.json
@@ -1,8 +1,0 @@
-{
-  "require-dev": {
-	"dealerdirect/phpcodesniffer-composer-installer": "^0.5.0",
-	"phpcompatibility/php-compatibility": "^9.0",
-	"squizlabs/php_codesniffer": "^3.3.1",
-	"wp-coding-standards/wpcs": "^2.2"
-  }
-}

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,48 @@
+language: php
+sudo: false
+dist: trusty
+
+cache:
+  directories:
+    - node_modules
+    - vendor
+    - $HOME/.composer/cache
+
+env:
+  global:
+    - WP_VERSION=latest WP_MULTISITE=0
+    - WP_TRAVISCI="travis:phpunit"
+
+matrix:
+  include:
+    - php: 5.6
+    - php: 7.2
+    - php: 7.3
+
+before_install:
+  - travis_retry composer self-update
+
+install:
+  - composer install --prefer-source --no-interaction --dev
+  - composer global require "phpunit/phpunit=^5"
+
+before_script:
+  - export PATH="$HOME/.composer/vendor/bin:$PATH"
+  - |
+    if [ -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini ]; then
+      phpenv config-rm xdebug.ini
+    else
+      echo "xdebug.ini does not exist"
+    fi
+  - |
+    if [[ ! -z "$WP_VERSION" ]] ; then
+      bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
+      composer global require "phpunit/phpunit=^5"
+    fi
+
+script:
+  - composer run-tests
+
+notifications:
+  on_success: never
+  on_failure: always


### PR DESCRIPTION
This PR removes support for PrettyCI, continuous integration for PHP coding standards. As a replacement, a `.travis.yml` file configuration for TravisCI is added. 