### PR TITLE
[WIP]PR#11 ( renderFormFeaturedImageAndCaption )

### DIFF
--- a/src/support/load-assets.php
+++ b/src/support/load-assets.php
@@ -41,7 +41,7 @@ function render_form_featured_image_and_caption( $form_id, $size = 'large' ) {
 	// Get the featured-image ID to render the image and caption on the donation page.
 	$options       = get_option( 'extend-give-wp', [] );
 	$attachment_id = isset( $options['featured-image-id'] ) ? (int) $options['featured-image-id'] : 0;
-	$post          = get_post( $attachment_id );
+	$post_excerpt  = get_post_field( 'post_excerpt', $attachment_id );
 
 	require_once _get_plugin_dir() . '/src/views/donation-form/featured-image-view.php';
 }

--- a/src/views/donation-form/featured-image-view.php
+++ b/src/views/donation-form/featured-image-view.php
@@ -5,5 +5,5 @@
 ?>
 <figure id="donation-form-featured-image" class="donate-page-featured-image attachment-<?php echo esc_attr( $attachment_id ); ?>" aria-describedby="donation-form-featured-image">
 	<?php echo wp_get_attachment_image( $attachment_id, $size, $icon = false, $attr = [ 'class' => 'featured-image' ] ); ?>
-	<figcaption id="donation-form-image-caption" class="featured-image-caption"><em><?php echo esc_attr( $post->post_excerpt ); ?></em></figcaption>
+	<figcaption id="donation-form-image-caption" class="featured-image-caption"><em><?php echo esc_attr( $post_excerpt ); ?></em></figcaption>
 </figure>

--- a/tests/phpunit/Integration/support/renderFormFeaturedImageAndCaption.php
+++ b/tests/phpunit/Integration/support/renderFormFeaturedImageAndCaption.php
@@ -28,10 +28,20 @@ use function spiralWebDb\ExtendGiveWP\render_form_featured_image_and_caption;
 class Tests_RenderFormFeaturedImageAndCaption extends TestCase {
 
 	/**
+	 * Clean up the test environment after each test.
+	 */
+	public function tearDown() {
+		parent::tearDown();
+
+		// Database cleanup.
+		delete_option( 'extend-give-wp' );
+	}
+
+	/**
 	 *  Test should check callback registered to action hook has expected priority.
 	 */
 	public function test_callback_registered_to_action_hook_has_expected_priority() {
-		$this->assertEquals( 5, has_action( 'give_pre_form', 'spiralWebDb\ExtendGiveWP\get_give_donation_form_id' ) );
+		$this->assertEquals( 10, has_action( 'give_pre_form', 'spiralWebDb\ExtendGiveWP\render_form_featured_image_and_caption' ) );
 	}
 
 	/**
@@ -39,10 +49,36 @@ class Tests_RenderFormFeaturedImageAndCaption extends TestCase {
 	 *
 	 * @dataProvider addTestData
 	 */
-	public function test_should_return_the_donation_form_id_when_given_post_id( $form_id, $args, $starts_with, $ends_with ) {
-		$form_id       = get_give_donation_form_id( $form_id );
-		$attachment_id = $this->factory()->attachment->create_object( $args );
-		$post_excerpt  = get_post_field( 'post_excerpt', $attachment_id );
+	public function test_should_return_the_donation_form_id_when_given_post_id( $option, $excerpt, $starts_with, $ends_with ) {
+		$form_id = $this->factory()->post->create();
+		$form_id = get_give_donation_form_id( $form_id );
+
+		// Add option to database so it can be called.
+		add_option( 'extend-give-wp', $option );
+		$options = get_option( 'extend-give-wp', [] );
+
+		// Test that the option was added and returns the expected value.
+		$this->assertTrue( isset( $options ) );
+		$this->assertTrue( isset( $option ) );
+
+		$attachment_id = isset( $options['featured-image-id'] ) ? (int) $options['featured-image-id'] : 0;
+
+		// Create and update an attachment fixture for the test method.
+		$args       = [
+			'ID'           => $attachment_id,
+			'post_excerpt' => $excerpt,
+			'post_parent'  => $form_id,
+			'post_type'    => 'attachment',
+		];
+		$attachment = $this->factory()->attachment->create_object( $args );
+		// Note: use of core function `wp_update_post` failed to update post_excerpt of attachment object.
+		// Note: use of core function `wp_insert_attachment` returned 0. Failed to update attachment object.
+		// Note: use of factory method for $attachment property returned 0. Failed to update attachment object.
+		// Question: How can the attachment (featured image) object be updated to include both the $attachment_id AND the 'post_excerpt'?
+
+		// Note: This returns falsey (empty string). How to access the 'post_excerpt' from the attachment object?
+		$post_excerpt = get_post_field( 'post_excerpt', $attachment_id );
+
 		wp_get_attachment_image( $attachment_id, 'large', $icon = false, $attr = [ 'class' => 'featured-image' ] );
 
 		ob_start();
@@ -57,27 +93,14 @@ class Tests_RenderFormFeaturedImageAndCaption extends TestCase {
 	 *  Data provider for integration test method.
 	 */
 	public function addTestData() {
-		$form_id = $this->factory()->post->create();
-
 		return [
-			'post data is empty'     => [
-				'form_id'          => 0,
-				'attachment_args'  => [
-					'post_excerpt' => '',
+			'featured image is not empty' => [
+				'option'           => [
+					'featured-image-id' => 144,
 				],
-				'view_starts_with' => '',
-				'view_ends_with'   => '',
-			],
-			'post data is not empty' => [
-				'form_id'          => $form_id,
-				'options'          => [
-					'featured_image_id' => 144,
-				],
-				'attachment_args'  => [
-					'post_excerpt' => 'Members of the Cornerstone Chorale & Brass during their 2018 tour.',
-				],
+				'post_excerpt'     => 'Members of the Cornerstone Chorale & Brass during their 2018 tour.',
 				'view_starts_with' => <<<FEATURED_IMAGE_VIEW_STARTS_WITH
-<figure id="donation-form-featured-image" class="donate-page-featured-image attachment-0" aria-describedby="donation-form-featured-image">
+<figure id="donation-form-featured-image" class="donate-page-featured-image attachment-144" aria-describedby="donation-form-featured-image">
 FEATURED_IMAGE_VIEW_STARTS_WITH
 				,
 				'view_ends_with'   => <<<FEATURED_IMAGE_VIEW_ENDS_WITH

--- a/tests/phpunit/Integration/support/renderFormFeaturedImageAndCaption.php
+++ b/tests/phpunit/Integration/support/renderFormFeaturedImageAndCaption.php
@@ -39,31 +39,42 @@ class Tests_RenderFormFeaturedImageAndCaption extends TestCase {
 	 *
 	 * @dataProvider addTestData
 	 */
-	public function test_should_return_the_donation_form_id_when_given_post_id( $option, $excerpt ) {
+	public function test_should_return_the_donation_form_id_when_given_post_id( $args, $starts_with, $ends_with ) {
 		$form_id       = $this->factory()->post->create();
 		$form_id       = get_give_donation_form_id( $form_id );
-		$options       = add_option( 'extend-give-wp', $option['featured-image-id'] );
-		$attachment_id = get_option( 'extend-give-wp' );
-		$post_excerpt  = get_post_field( $excerpt, $attachment_id );
+		$attachment_id = $this->factory()->attachment->create_object( $args );
+		$post_excerpt  = get_post_field( 'post_excerpt', $attachment_id );
+		wp_get_attachment_image( $attachment_id, 'large', $icon = false, $attr = [ 'class' => 'featured-image' ] );
 
 		ob_start();
-		echo wp_get_attachment_image( $attachment_id, $size = 'large', $icon = false, $attr = [ 'class' => 'featured-image' ] );
 		render_form_featured_image_and_caption( $form_id, 'large' );
 		$actual = ob_get_clean();
 
-//		$this->assertSame( $form_id, render_form_featured_image_and_caption( $form_id, $size = 'large' ) );
+		$this->assertStringStartsWith( $starts_with, $actual );
+		$this->assertStringEndsWith( $ends_with, $actual );
 	}
 
+	/**
+	 *  Data provider for integration test method.
+	 */
 	public function addTestData() {
 		return [
 			'render_donation_form ' => [
-				'option_data'  => [
-					'featured-image-id' => 144
+				'attachment_args'  => [
+					'post_title'   => '2018 Cornerstone Tour members | 1024 x 819',
+					'post_excerpt' => 'Members of the Cornerstone Chorale & Brass during their 2018 tour.',
 				],
-				'post_excerpt' => 'Members of the Cornerstone Chorale & Brass during their 2018 tour.'
-			]
+				'view_starts_with' => <<<FEATURED_IMAGE_VIEW_STARTS_WITH
+<figure id="donation-form-featured-image" class="donate-page-featured-image attachment-0" aria-describedby="donation-form-featured-image">
+FEATURED_IMAGE_VIEW_STARTS_WITH
+				,
+				'view_ends_with'   => <<<FEATURED_IMAGE_VIEW_ENDS_WITH
+	<figcaption id="donation-form-image-caption" class="featured-image-caption"><em>Members of the Cornerstone Chorale & Brass during their 2018 tour.</em></figcaption>
+</figure>
+FEATURED_IMAGE_VIEW_ENDS_WITH
+				,
+			],
 		];
 	}
 }
-
 

--- a/tests/phpunit/Integration/support/renderFormFeaturedImageAndCaption.php
+++ b/tests/phpunit/Integration/support/renderFormFeaturedImageAndCaption.php
@@ -39,8 +39,7 @@ class Tests_RenderFormFeaturedImageAndCaption extends TestCase {
 	 *
 	 * @dataProvider addTestData
 	 */
-	public function test_should_return_the_donation_form_id_when_given_post_id( $args, $starts_with, $ends_with ) {
-		$form_id       = $this->factory()->post->create();
+	public function test_should_return_the_donation_form_id_when_given_post_id( $form_id, $args, $starts_with, $ends_with ) {
 		$form_id       = get_give_donation_form_id( $form_id );
 		$attachment_id = $this->factory()->attachment->create_object( $args );
 		$post_excerpt  = get_post_field( 'post_excerpt', $attachment_id );
@@ -58,10 +57,23 @@ class Tests_RenderFormFeaturedImageAndCaption extends TestCase {
 	 *  Data provider for integration test method.
 	 */
 	public function addTestData() {
+		$form_id = $this->factory()->post->create();
+
 		return [
-			'render_donation_form ' => [
+			'post data is empty'     => [
+				'form_id'          => 0,
 				'attachment_args'  => [
-					'post_title'   => '2018 Cornerstone Tour members | 1024 x 819',
+					'post_excerpt' => '',
+				],
+				'view_starts_with' => '',
+				'view_ends_with'   => '',
+			],
+			'post data is not empty' => [
+				'form_id'          => $form_id,
+				'options'          => [
+					'featured_image_id' => 144,
+				],
+				'attachment_args'  => [
 					'post_excerpt' => 'Members of the Cornerstone Chorale & Brass during their 2018 tour.',
 				],
 				'view_starts_with' => <<<FEATURED_IMAGE_VIEW_STARTS_WITH

--- a/tests/phpunit/Integration/support/renderFormFeaturedImageAndCaption.php
+++ b/tests/phpunit/Integration/support/renderFormFeaturedImageAndCaption.php
@@ -1,0 +1,69 @@
+<?php
+/**
+ *  Tests for render_form_featured_image_and_caption()
+ *
+ * @since      1.0.0
+ * @author     Robert A. Gadon
+ * @package    spiralWebDb\ExtendGiveWP\Tests\Integration
+ * @link       http://spiralwebdb.com
+ * @license    GNU General Public License 2.0+
+ */
+
+namespace spiralWebDb\ExtendGiveWP\Tests\Integration;
+
+use spiralWebDb\ExtendGiveWP\tests\phpunit\Integration\TestCase;
+use function spiralWebDb\ExtendGiveWP\get_give_donation_form_id;
+use function spiralWebDb\ExtendGiveWP\render_form_featured_image_and_caption;
+
+/**
+ * Class Tests_RenderFormFeaturedImageAndCaption
+ *
+ * @covers ::\spiralWebDb\ExtendGiveWP\render_form_featured_image_and_caption
+ *
+ * @group   extend-give-wp
+ * @group   support
+ *
+ * phpcs:disable Squiz.Commenting.FunctionComment.MissingParamTag
+ */
+class Tests_RenderFormFeaturedImageAndCaption extends TestCase {
+
+	/**
+	 *  Test should check callback registered to action hook has expected priority.
+	 */
+	public function test_callback_registered_to_action_hook_has_expected_priority() {
+		$this->assertEquals( 5, has_action( 'give_pre_form', 'spiralWebDb\ExtendGiveWP\get_give_donation_form_id' ) );
+	}
+
+	/**
+	 *  Test get_give_donation_form_id() should return the donation form_id when given the post_id.
+	 *
+	 * @dataProvider addTestData
+	 */
+	public function test_should_return_the_donation_form_id_when_given_post_id( $option, $excerpt ) {
+		$form_id       = $this->factory()->post->create();
+		$form_id       = get_give_donation_form_id( $form_id );
+		$options       = add_option( 'extend-give-wp', $option['featured-image-id'] );
+		$attachment_id = get_option( 'extend-give-wp' );
+		$post_excerpt  = get_post_field( $excerpt, $attachment_id );
+
+		ob_start();
+		echo wp_get_attachment_image( $attachment_id, $size = 'large', $icon = false, $attr = [ 'class' => 'featured-image' ] );
+		render_form_featured_image_and_caption( $form_id, 'large' );
+		$actual = ob_get_clean();
+
+//		$this->assertSame( $form_id, render_form_featured_image_and_caption( $form_id, $size = 'large' ) );
+	}
+
+	public function addTestData() {
+		return [
+			'render_donation_form ' => [
+				'option_data'  => [
+					'featured-image-id' => 144
+				],
+				'post_excerpt' => 'Members of the Cornerstone Chorale & Brass during their 2018 tour.'
+			]
+		];
+	}
+}
+
+

--- a/tests/phpunit/Unit/support/renderFormFeaturedImageAndCaption.php
+++ b/tests/phpunit/Unit/support/renderFormFeaturedImageAndCaption.php
@@ -49,10 +49,10 @@ class Tests_RenderFormFeaturedImageAndCaption extends TestCase {
 		Functions\expect( 'get_option' )
 			->zeroOrMoreTimes()
 			->with( 'extend-give-wp', [] )
-			->andReturn( $options['featured_image_id'] );
+			->andReturn( $options['featured-image-id'] );
 		Functions\expect( 'get_post_field' )
 			->zeroOrMoreTimes()
-			->with( 'post_excerpt', $options['featured_image_id'] )
+			->with( 'post_excerpt', $options['featured-image-id'] )
 			->andReturn( $excerpt );
 		Functions\when( 'wp_get_attachment_image' )->justReturn();
 		Functions\expect( '_get_plugin_dir' )->andReturn( EXTEND_GIVE_WP_ROOT_DIR );
@@ -72,7 +72,7 @@ class Tests_RenderFormFeaturedImageAndCaption extends TestCase {
 			'post data is empty'     => [
 				'form_id'       => '',
 				'options'       => [
-					'featured_image_id' => '',
+					'featured-image-id' => '',
 				],
 				'post_excerpt'  => '',
 				'expected_view' => '',
@@ -80,7 +80,7 @@ class Tests_RenderFormFeaturedImageAndCaption extends TestCase {
 			'post data is not empty' => [
 				'form_id'       => 39,
 				'options'       => [
-					'featured_image_id' => 144,
+					'featured-image-id' => 144,
 				],
 				'post_excerpt'  => 'Members of the Cornerstone Chorale & Brass during their 2018 tour.',
 				'expected_view' => <<<FEATURED_IMAGE_VIEW

--- a/tests/phpunit/Unit/support/renderFormFeaturedImageAndCaption.php
+++ b/tests/phpunit/Unit/support/renderFormFeaturedImageAndCaption.php
@@ -49,10 +49,10 @@ class Tests_RenderFormFeaturedImageAndCaption extends TestCase {
 		Functions\expect( 'get_option' )
 			->zeroOrMoreTimes()
 			->with( 'extend-give-wp', [] )
-			->andReturn( $options );
+			->andReturn( $options['featured_image_id'] );
 		Functions\expect( 'get_post_field' )
 			->zeroOrMoreTimes()
-			->with( 'post_excerpt', 'attachment_id' )
+			->with( 'post_excerpt', $options['featured_image_id'] )
 			->andReturn( $excerpt );
 		Functions\when( 'wp_get_attachment_image' )->justReturn();
 		Functions\expect( '_get_plugin_dir' )->andReturn( EXTEND_GIVE_WP_ROOT_DIR );

--- a/tests/phpunit/Unit/support/renderFormFeaturedImageAndCaption.php
+++ b/tests/phpunit/Unit/support/renderFormFeaturedImageAndCaption.php
@@ -22,6 +22,8 @@ use function spiralWebDb\ExtendGiveWP\render_form_featured_image_and_caption;
  *
  * @group   extend-give-wp
  * @group   support
+ *
+ * phpcs:disable Squiz.Commenting.FunctionComment.MissingParamTag
  */
 class Tests_RenderFormFeaturedImageAndCaption extends TestCase {
 

--- a/tests/phpunit/Unit/support/renderFormFeaturedImageAndCaption.php
+++ b/tests/phpunit/Unit/support/renderFormFeaturedImageAndCaption.php
@@ -52,13 +52,14 @@ class Tests_RenderFormFeaturedImageAndCaption extends TestCase {
 			->andReturn( $post_data['attachment_id'] );
 		Functions\expect( 'get_post_field' )
 			->once()
-			->with( 'post_excerpt', $post_data['attachment_id'] )
+			->with( 'post_excerpt', 'attachment_id' )
 			->andReturn( $post_data['post_excerpt'] );
 		Functions\expect( 'wp_get_attachment_image' )
 			->once()
 			->with( $post_data['attachment_id'], 'large', false, [ 'class' => 'featured-image' ] )
 			->andReturn( $html );
 		Functions\expect( '_get_plugin_dir' )->andReturn( EXTEND_GIVE_WP_ROOT_DIR );
+		Functions\when( 'esc_attr')->justEcho();
 
 		ob_start();
 		render_form_featured_image_and_caption( $post_data['form_id'], 'large' );

--- a/tests/phpunit/Unit/support/renderFormFeaturedImageAndCaption.php
+++ b/tests/phpunit/Unit/support/renderFormFeaturedImageAndCaption.php
@@ -25,6 +25,9 @@ use function spiralWebDb\ExtendGiveWP\render_form_featured_image_and_caption;
  */
 class Tests_RenderFormFeaturedImageAndCaption extends TestCase {
 
+	/**
+	 * Prepares the test environment before each test.
+	 */
 	public function setUp() {
 		parent::setUp();
 
@@ -32,6 +35,8 @@ class Tests_RenderFormFeaturedImageAndCaption extends TestCase {
 	}
 
 	/**
+	 * Test should render form featured image and caption given $form_id and image size.
+	 *
 	 * @dataProvider addTestData
 	 */
 	public function test_should_render_form_featured_image_and_caption( $post_data, $html, $expected_view ) {
@@ -60,13 +65,16 @@ class Tests_RenderFormFeaturedImageAndCaption extends TestCase {
 		$this->assertSame( $expected_view, $actual_view );
 	}
 
+	/**
+	 *  Data provider for unit test method.
+	 */
 	public function addTestData() {
 		return [
 			'donation form featured image and caption' => [
 				'post_data'           => [
 					'form_id'       => 39,
 					'attachment_id' => 144,
-					'post_excerpt'  => 'Members of the Cornerstone Chorale & Brass during their 2018 tour.'
+					'post_excerpt'  => 'Members of the Cornerstone Chorale & Brass during their 2018 tour.',
 				],
 				'expected_html_image' => <<<HTML_IMAGE
 <img src="https://i2.wp.com/cornerstonechorale.org/wp-content/uploads/2019/11/2018-Cornerstone-Tour-members-1024-x-819.jpg?fit=1024%2C819&&ssl=1" class="featured-image jetpack-lazy-image jetpack-lazy-image--handled" alt="tour members of the 2018 cornerstone chorale and brass" data-attachment-id="1411" data-permalink="https://cornerstonechorale.org/2018-cornerstone-tour-members-1024-x-819/" data-orig-file="https://i2.wp.com/cornerstonechorale.org/wp-content/uploads/2019/11/2018-Cornerstone-Tour-members-1024-x-819.jpg?fit=1024%2C819&&ssl=1" data-orig-size="1024,819" data-comments-opened="0" data-image-meta=“{“aperture”:”0”,”credit”:””,”camera”:””,”caption”:””,”created_timestamp”:”0”,”copyright”:””,”focal_length”:”0”,”iso”:”0”,”shutter_speed”:”0”,”title”:””,”orientation”:”1”}” data-image-title="2018 Cornerstone Tour members | 1024 x 819" data-image-description="" data-medium-file="https://i2.wp.com/cornerstonechorale.org/wp-content/uploads/2019/11/2018-Cornerstone-Tour-members-1024-x-819.jpg?fit=300%2C240&&ssl=1" data-large-file="https://i2.wp.com/cornerstonechorale.org/wp-content/uploads/2019/11/2018-Cornerstone-Tour-members-1024-x-819.jpg?fit=1024%2C819&&ssl=1" srcset="https://i2.wp.com/cornerstonechorale.org/wp-content/uploads/2019/11/2018-Cornerstone-Tour-members-1024-x-819.jpg?w=1024&&ssl=1 1024w, https://i2.wp.com/cornerstonechorale.org/wp-content/uploads/2019/11/2018-Cornerstone-Tour-members-1024-x-819.jpg?resize=300%2C240&&ssl=1 300w, https://i2.wp.com/cornerstonechorale.org/wp-content/uploads/2019/11/2018-Cornerstone-Tour-members-1024-x-819.jpg?resize=768%2C614&&ssl=1 768w" data-lazy-loaded="1" sizes="(max-width: 1000px) 100vw, 1000px" width="1024" height="819">
@@ -79,7 +87,7 @@ HTML_IMAGE
 </figure>
 FEATURED_IMAGE_VIEW
 				,
-			]
+			],
 		];
 	}
 }

--- a/tests/phpunit/Unit/support/renderFormFeaturedImageAndCaption.php
+++ b/tests/phpunit/Unit/support/renderFormFeaturedImageAndCaption.php
@@ -49,10 +49,10 @@ class Tests_RenderFormFeaturedImageAndCaption extends TestCase {
 		Functions\expect( 'get_option' )
 			->zeroOrMoreTimes()
 			->with( 'extend-give-wp', [] )
-			->andReturn( $options['featured-image-id'] );
+			->andReturn( $options );
 		Functions\expect( 'get_post_field' )
 			->zeroOrMoreTimes()
-			->with( 'post_excerpt', $options['featured-image-id'] )
+			->with( 'post_excerpt', 'attachment_id' )
 			->andReturn( $excerpt );
 		Functions\when( 'wp_get_attachment_image' )->justReturn();
 		Functions\expect( '_get_plugin_dir' )->andReturn( EXTEND_GIVE_WP_ROOT_DIR );
@@ -61,7 +61,7 @@ class Tests_RenderFormFeaturedImageAndCaption extends TestCase {
 		render_form_featured_image_and_caption( $form_id, 'large' );
 		$actual_view = ob_get_clean();
 
-		$this->assertSame( $expected_view, $actual_view );
+		$this->assertEquals( $expected_view, $actual_view );
 	}
 
 	/**
@@ -69,15 +69,15 @@ class Tests_RenderFormFeaturedImageAndCaption extends TestCase {
 	 */
 	public function addTestData() {
 		return [
-			'post data is empty'       => [
+			'post data is empty'     => [
 				'form_id'       => '',
 				'options'       => [
-					'featured_image_id' => 0,
+					'featured_image_id' => '',
 				],
 				'post_excerpt'  => '',
 				'expected_view' => '',
 			],
-			'post data is non - empty' => [
+			'post data is not empty' => [
 				'form_id'       => 39,
 				'options'       => [
 					'featured_image_id' => 144,

--- a/tests/phpunit/Unit/support/renderFormFeaturedImageAndCaption.php
+++ b/tests/phpunit/Unit/support/renderFormFeaturedImageAndCaption.php
@@ -50,10 +50,10 @@ class Tests_RenderFormFeaturedImageAndCaption extends TestCase {
 			->once()
 			->with( 'extend-give-wp', [] )
 			->andReturn( $post_data['attachment_id'] );
-		Functions\expect( 'get_post' )
+		Functions\expect( 'get_post_field' )
 			->once()
-			->with( $post_data['attachment_id'] )
-			->andReturn( 'WP_Post' );
+			->with( 'post_excerpt', $post_data['attachment_id'] )
+			->andReturn( $post_data['post_excerpt'] );
 		Functions\expect( 'wp_get_attachment_image' )
 			->once()
 			->with( $post_data['attachment_id'], 'large', false, [ 'class' => 'featured-image' ] )

--- a/tests/phpunit/Unit/support/renderFormFeaturedImageAndCaption.php
+++ b/tests/phpunit/Unit/support/renderFormFeaturedImageAndCaption.php
@@ -32,7 +32,7 @@ class Tests_RenderFormFeaturedImageAndCaption extends TestCase {
 	 */
 	public function setUp() {
 		parent::setUp();
-
+		$this->setup_common_wp_stubs();
 		require_once EXTEND_GIVE_WP_ROOT_DIR . '/src/support/load-assets.php';
 	}
 
@@ -41,7 +41,7 @@ class Tests_RenderFormFeaturedImageAndCaption extends TestCase {
 	 *
 	 * @dataProvider addTestData
 	 */
-	public function test_should_render_form_featured_image_and_caption( $form_id, $attachment_id, $excerpt, $expected_view ) {
+	public function test_should_render_form_featured_image_and_caption( $form_id, $options, $excerpt, $expected_view ) {
 		Functions\expect( 'get_give_donation_form_id' )
 			->zeroOrMoreTimes()
 			->with( 'form_id' )
@@ -49,21 +49,13 @@ class Tests_RenderFormFeaturedImageAndCaption extends TestCase {
 		Functions\expect( 'get_option' )
 			->zeroOrMoreTimes()
 			->with( 'extend-give-wp', [] )
-			->andReturn( $attachment_id );
+			->andReturn( $options['featured-image-id'] );
 		Functions\expect( 'get_post_field' )
 			->zeroOrMoreTimes()
-			->with( 'post_excerpt', 'attachment_id' )
+			->with( 'post_excerpt', $options['featured-image-id'] )
 			->andReturn( $excerpt );
 		Functions\when( 'wp_get_attachment_image' )->justReturn();
 		Functions\expect( '_get_plugin_dir' )->andReturn( EXTEND_GIVE_WP_ROOT_DIR );
-		Functions\expect( 'esc_attr' )
-			->zeroOrMoreTimes()
-			->with( 'attachment_id' )
-			->andReturn( $attachment_id )
-			->andAlsoExpectIt()
-			->zeroOrMoreTimes()
-			->with( 'post_excerpt' )
-			->andReturn( $excerpt );
 
 		ob_start();
 		render_form_featured_image_and_caption( $form_id, 'large' );
@@ -77,15 +69,19 @@ class Tests_RenderFormFeaturedImageAndCaption extends TestCase {
 	 */
 	public function addTestData() {
 		return [
-			'post data is empty'     => [
+			'post data is empty'       => [
 				'form_id'       => '',
-				'attachment_id' => 0,
+				'options'       => [
+					'featured_image_id' => 0,
+				],
 				'post_excerpt'  => '',
 				'expected_view' => '',
 			],
-			'post data is non-empty' => [
+			'post data is non - empty' => [
 				'form_id'       => 39,
-				'attachment_id' => 144,
+				'options'       => [
+					'featured_image_id' => 144,
+				],
 				'post_excerpt'  => 'Members of the Cornerstone Chorale & Brass during their 2018 tour.',
 				'expected_view' => <<<FEATURED_IMAGE_VIEW
 <figure id="donation-form-featured-image" class="donate-page-featured-image attachment-144" aria-describedby="donation-form-featured-image">

--- a/tests/phpunit/Unit/support/renderFormFeaturedImageAndCaption.php
+++ b/tests/phpunit/Unit/support/renderFormFeaturedImageAndCaption.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ *  Tests for render_form_featured_image_and_caption()
+ *
+ * @since      1.0.0
+ * @author     Robert A. Gadon
+ * @package    spiralWebDb\ExtendGiveWP\Tests\Unit
+ * @link       http://spiralwebdb.com
+ * @license    GNU General Public License 2.0+
+ */
+
+namespace spiralWebDb\ExtendGiveWP\Tests\Unit;
+
+use Brain\Monkey\Functions;
+use spiralWebDb\ExtendGiveWP\tests\phpunit\Unit\TestCase;
+use function spiralWebDb\ExtendGiveWP\render_form_featured_image_and_caption;
+
+/**
+ * Class Tests_RenderFormFeaturedImageAndCaption
+ *
+ * @covers ::\spiralWebDb\ExtendGiveWP\render_form_featured_image_and_caption
+ *
+ * @group   extend-give-wp
+ * @group   support
+ */
+class Tests_RenderFormFeaturedImageAndCaption extends TestCase {
+
+	public function setUp() {
+		parent::setUp();
+
+		require_once EXTEND_GIVE_WP_ROOT_DIR . '/src/support/load-assets.php';
+	}
+
+	/**
+	 * @dataProvider addTestData
+	 */
+	public function test_should_render_form_featured_image_and_caption( $post_data, $html, $expected_view ) {
+		Functions\expect( 'get_give_donation_form_id' )
+			->once()
+			->with( 'form_id' )
+			->andReturn( $post_data['form_id'] );
+		Functions\expect( 'get_option' )
+			->once()
+			->with( 'extend-give-wp', [] )
+			->andReturn( $post_data['attachment_id'] );
+		Functions\expect( 'get_post' )
+			->once()
+			->with( $post_data['attachment_id'] )
+			->andReturn( 'WP_Post' );
+		Functions\expect( 'wp_get_attachment_image' )
+			->once()
+			->with( $post_data['attachment_id'], 'large', false, [ 'class' => 'featured-image' ] )
+			->andReturn( $html );
+		Functions\expect( '_get_plugin_dir' )->andReturn( EXTEND_GIVE_WP_ROOT_DIR );
+
+		ob_start();
+		render_form_featured_image_and_caption( $post_data['form_id'], 'large' );
+		$actual_view = ob_get_clean();
+
+		$this->assertSame( $expected_view, $actual_view );
+	}
+
+	public function addTestData() {
+		return [
+			'donation form featured image and caption' => [
+				'post_data'           => [
+					'form_id'       => 39,
+					'attachment_id' => 144,
+					'post_excerpt'  => 'Members of the Cornerstone Chorale & Brass during their 2018 tour.'
+				],
+				'expected_html_image' => <<<HTML_IMAGE
+<img src="https://i2.wp.com/cornerstonechorale.org/wp-content/uploads/2019/11/2018-Cornerstone-Tour-members-1024-x-819.jpg?fit=1024%2C819&&ssl=1" class="featured-image jetpack-lazy-image jetpack-lazy-image--handled" alt="tour members of the 2018 cornerstone chorale and brass" data-attachment-id="1411" data-permalink="https://cornerstonechorale.org/2018-cornerstone-tour-members-1024-x-819/" data-orig-file="https://i2.wp.com/cornerstonechorale.org/wp-content/uploads/2019/11/2018-Cornerstone-Tour-members-1024-x-819.jpg?fit=1024%2C819&&ssl=1" data-orig-size="1024,819" data-comments-opened="0" data-image-meta=“{“aperture”:”0”,”credit”:””,”camera”:””,”caption”:””,”created_timestamp”:”0”,”copyright”:””,”focal_length”:”0”,”iso”:”0”,”shutter_speed”:”0”,”title”:””,”orientation”:”1”}” data-image-title="2018 Cornerstone Tour members | 1024 x 819" data-image-description="" data-medium-file="https://i2.wp.com/cornerstonechorale.org/wp-content/uploads/2019/11/2018-Cornerstone-Tour-members-1024-x-819.jpg?fit=300%2C240&&ssl=1" data-large-file="https://i2.wp.com/cornerstonechorale.org/wp-content/uploads/2019/11/2018-Cornerstone-Tour-members-1024-x-819.jpg?fit=1024%2C819&&ssl=1" srcset="https://i2.wp.com/cornerstonechorale.org/wp-content/uploads/2019/11/2018-Cornerstone-Tour-members-1024-x-819.jpg?w=1024&&ssl=1 1024w, https://i2.wp.com/cornerstonechorale.org/wp-content/uploads/2019/11/2018-Cornerstone-Tour-members-1024-x-819.jpg?resize=300%2C240&&ssl=1 300w, https://i2.wp.com/cornerstonechorale.org/wp-content/uploads/2019/11/2018-Cornerstone-Tour-members-1024-x-819.jpg?resize=768%2C614&&ssl=1 768w" data-lazy-loaded="1" sizes="(max-width: 1000px) 100vw, 1000px" width="1024" height="819">
+HTML_IMAGE
+				,
+				'expected_view'       => <<<FEATURED_IMAGE_VIEW
+<figure id="donation-form-featured-image" class="donate-page-featured-image attachment-144" aria-describedby="donation-form-featured-image">
+	<img src="https://i2.wp.com/cornerstonechorale.org/wp-content/uploads/2019/11/2018-Cornerstone-Tour-members-1024-x-819.jpg?fit=1024%2C819&&ssl=1" class="featured-image jetpack-lazy-image jetpack-lazy-image--handled" alt="tour members of the 2018 cornerstone chorale and brass" data-attachment-id="1411" data-permalink="https://cornerstonechorale.org/2018-cornerstone-tour-members-1024-x-819/" data-orig-file="https://i2.wp.com/cornerstonechorale.org/wp-content/uploads/2019/11/2018-Cornerstone-Tour-members-1024-x-819.jpg?fit=1024%2C819&&ssl=1" data-orig-size="1024,819" data-comments-opened="0" data-image-meta=“{“aperture”:”0”,”credit”:””,”camera”:””,”caption”:””,”created_timestamp”:”0”,”copyright”:””,”focal_length”:”0”,”iso”:”0”,”shutter_speed”:”0”,”title”:””,”orientation”:”1”}” data-image-title="2018 Cornerstone Tour members | 1024 x 819" data-image-description="" data-medium-file="https://i2.wp.com/cornerstonechorale.org/wp-content/uploads/2019/11/2018-Cornerstone-Tour-members-1024-x-819.jpg?fit=300%2C240&&ssl=1" data-large-file="https://i2.wp.com/cornerstonechorale.org/wp-content/uploads/2019/11/2018-Cornerstone-Tour-members-1024-x-819.jpg?fit=1024%2C819&&ssl=1" srcset="https://i2.wp.com/cornerstonechorale.org/wp-content/uploads/2019/11/2018-Cornerstone-Tour-members-1024-x-819.jpg?w=1024&&ssl=1 1024w, https://i2.wp.com/cornerstonechorale.org/wp-content/uploads/2019/11/2018-Cornerstone-Tour-members-1024-x-819.jpg?resize=300%2C240&&ssl=1 300w, https://i2.wp.com/cornerstonechorale.org/wp-content/uploads/2019/11/2018-Cornerstone-Tour-members-1024-x-819.jpg?resize=768%2C614&&ssl=1 768w" data-lazy-loaded="1" sizes="(max-width: 1000px) 100vw, 1000px" width="1024" height="819">
+	<figcaption id="donation-form-image-caption" class="featured-image-caption"><em>Members of the Cornerstone Chorale & Brass during their 2018 tour.</em></figcaption>
+</figure>
+FEATURED_IMAGE_VIEW
+				,
+			]
+		];
+	}
+}
+

--- a/tests/phpunit/Unit/support/renderFormFeaturedImageAndCaption.php
+++ b/tests/phpunit/Unit/support/renderFormFeaturedImageAndCaption.php
@@ -41,28 +41,32 @@ class Tests_RenderFormFeaturedImageAndCaption extends TestCase {
 	 *
 	 * @dataProvider addTestData
 	 */
-	public function test_should_render_form_featured_image_and_caption( $post_data, $html, $expected_view ) {
+	public function test_should_render_form_featured_image_and_caption( $form_id, $attachment_id, $excerpt, $expected_view ) {
 		Functions\expect( 'get_give_donation_form_id' )
-			->once()
+			->zeroOrMoreTimes()
 			->with( 'form_id' )
-			->andReturn( $post_data['form_id'] );
+			->andReturn( $form_id );
 		Functions\expect( 'get_option' )
-			->once()
+			->zeroOrMoreTimes()
 			->with( 'extend-give-wp', [] )
-			->andReturn( $post_data['attachment_id'] );
+			->andReturn( $attachment_id );
 		Functions\expect( 'get_post_field' )
-			->once()
+			->zeroOrMoreTimes()
 			->with( 'post_excerpt', 'attachment_id' )
-			->andReturn( $post_data['post_excerpt'] );
-		Functions\expect( 'wp_get_attachment_image' )
-			->once()
-			->with( $post_data['attachment_id'], 'large', false, [ 'class' => 'featured-image' ] )
-			->andReturn( $html );
+			->andReturn( $excerpt );
+		Functions\when( 'wp_get_attachment_image' )->justReturn();
 		Functions\expect( '_get_plugin_dir' )->andReturn( EXTEND_GIVE_WP_ROOT_DIR );
-		Functions\when( 'esc_attr')->justEcho();
+		Functions\expect( 'esc_attr' )
+			->zeroOrMoreTimes()
+			->with( 'attachment_id' )
+			->andReturn( $attachment_id )
+			->andAlsoExpectIt()
+			->zeroOrMoreTimes()
+			->with( 'post_excerpt' )
+			->andReturn( $excerpt );
 
 		ob_start();
-		render_form_featured_image_and_caption( $post_data['form_id'], 'large' );
+		render_form_featured_image_and_caption( $form_id, 'large' );
 		$actual_view = ob_get_clean();
 
 		$this->assertSame( $expected_view, $actual_view );
@@ -73,19 +77,18 @@ class Tests_RenderFormFeaturedImageAndCaption extends TestCase {
 	 */
 	public function addTestData() {
 		return [
-			'donation form featured image and caption' => [
-				'post_data'           => [
-					'form_id'       => 39,
-					'attachment_id' => 144,
-					'post_excerpt'  => 'Members of the Cornerstone Chorale & Brass during their 2018 tour.',
-				],
-				'expected_html_image' => <<<HTML_IMAGE
-<img src="https://i2.wp.com/cornerstonechorale.org/wp-content/uploads/2019/11/2018-Cornerstone-Tour-members-1024-x-819.jpg?fit=1024%2C819&&ssl=1" class="featured-image jetpack-lazy-image jetpack-lazy-image--handled" alt="tour members of the 2018 cornerstone chorale and brass" data-attachment-id="1411" data-permalink="https://cornerstonechorale.org/2018-cornerstone-tour-members-1024-x-819/" data-orig-file="https://i2.wp.com/cornerstonechorale.org/wp-content/uploads/2019/11/2018-Cornerstone-Tour-members-1024-x-819.jpg?fit=1024%2C819&&ssl=1" data-orig-size="1024,819" data-comments-opened="0" data-image-meta=“{“aperture”:”0”,”credit”:””,”camera”:””,”caption”:””,”created_timestamp”:”0”,”copyright”:””,”focal_length”:”0”,”iso”:”0”,”shutter_speed”:”0”,”title”:””,”orientation”:”1”}” data-image-title="2018 Cornerstone Tour members | 1024 x 819" data-image-description="" data-medium-file="https://i2.wp.com/cornerstonechorale.org/wp-content/uploads/2019/11/2018-Cornerstone-Tour-members-1024-x-819.jpg?fit=300%2C240&&ssl=1" data-large-file="https://i2.wp.com/cornerstonechorale.org/wp-content/uploads/2019/11/2018-Cornerstone-Tour-members-1024-x-819.jpg?fit=1024%2C819&&ssl=1" srcset="https://i2.wp.com/cornerstonechorale.org/wp-content/uploads/2019/11/2018-Cornerstone-Tour-members-1024-x-819.jpg?w=1024&&ssl=1 1024w, https://i2.wp.com/cornerstonechorale.org/wp-content/uploads/2019/11/2018-Cornerstone-Tour-members-1024-x-819.jpg?resize=300%2C240&&ssl=1 300w, https://i2.wp.com/cornerstonechorale.org/wp-content/uploads/2019/11/2018-Cornerstone-Tour-members-1024-x-819.jpg?resize=768%2C614&&ssl=1 768w" data-lazy-loaded="1" sizes="(max-width: 1000px) 100vw, 1000px" width="1024" height="819">
-HTML_IMAGE
-				,
-				'expected_view'       => <<<FEATURED_IMAGE_VIEW
+			'post data is empty'     => [
+				'form_id'       => '',
+				'attachment_id' => 0,
+				'post_excerpt'  => '',
+				'expected_view' => '',
+			],
+			'post data is non-empty' => [
+				'form_id'       => 39,
+				'attachment_id' => 144,
+				'post_excerpt'  => 'Members of the Cornerstone Chorale & Brass during their 2018 tour.',
+				'expected_view' => <<<FEATURED_IMAGE_VIEW
 <figure id="donation-form-featured-image" class="donate-page-featured-image attachment-144" aria-describedby="donation-form-featured-image">
-	<img src="https://i2.wp.com/cornerstonechorale.org/wp-content/uploads/2019/11/2018-Cornerstone-Tour-members-1024-x-819.jpg?fit=1024%2C819&&ssl=1" class="featured-image jetpack-lazy-image jetpack-lazy-image--handled" alt="tour members of the 2018 cornerstone chorale and brass" data-attachment-id="1411" data-permalink="https://cornerstonechorale.org/2018-cornerstone-tour-members-1024-x-819/" data-orig-file="https://i2.wp.com/cornerstonechorale.org/wp-content/uploads/2019/11/2018-Cornerstone-Tour-members-1024-x-819.jpg?fit=1024%2C819&&ssl=1" data-orig-size="1024,819" data-comments-opened="0" data-image-meta=“{“aperture”:”0”,”credit”:””,”camera”:””,”caption”:””,”created_timestamp”:”0”,”copyright”:””,”focal_length”:”0”,”iso”:”0”,”shutter_speed”:”0”,”title”:””,”orientation”:”1”}” data-image-title="2018 Cornerstone Tour members | 1024 x 819" data-image-description="" data-medium-file="https://i2.wp.com/cornerstonechorale.org/wp-content/uploads/2019/11/2018-Cornerstone-Tour-members-1024-x-819.jpg?fit=300%2C240&&ssl=1" data-large-file="https://i2.wp.com/cornerstonechorale.org/wp-content/uploads/2019/11/2018-Cornerstone-Tour-members-1024-x-819.jpg?fit=1024%2C819&&ssl=1" srcset="https://i2.wp.com/cornerstonechorale.org/wp-content/uploads/2019/11/2018-Cornerstone-Tour-members-1024-x-819.jpg?w=1024&&ssl=1 1024w, https://i2.wp.com/cornerstonechorale.org/wp-content/uploads/2019/11/2018-Cornerstone-Tour-members-1024-x-819.jpg?resize=300%2C240&&ssl=1 300w, https://i2.wp.com/cornerstonechorale.org/wp-content/uploads/2019/11/2018-Cornerstone-Tour-members-1024-x-819.jpg?resize=768%2C614&&ssl=1 768w" data-lazy-loaded="1" sizes="(max-width: 1000px) 100vw, 1000px" width="1024" height="819">
 	<figcaption id="donation-form-image-caption" class="featured-image-caption"><em>Members of the Cornerstone Chorale & Brass during their 2018 tour.</em></figcaption>
 </figure>
 FEATURED_IMAGE_VIEW


### PR DESCRIPTION
## PR Summary 

This pull request includes unit and integration tests for the function `render_form_featured_image_and_caption()` in the `extend-give-wp` plugin. The relative file path to the function under test is: 

>`extend-give-wp/src/support/load-assets.php`.

### Issues -- Unit Test

The unit and integration tests for this function are complicated by the fact that there are 2 variables, and a WP core function passed into the view. To simplify the testing scenarios, I removed the function `wp_get_attachment_image()` from the expected view in both the unit and test classes. That function returns an enormous `<img>` tag element that I currently find too complicated to mock or match with an actual value. 

I chose instead to test the HTML at the start and end of the view. Each HTML segment contains a variable escaped with `esc_attr()`.  [ I am now able to stub out `esc_attr()`. Thanks for that hint earlier.]

I can pass the `$post_excerpt` associated with the featured image into the view. I cannot pass the featured image ID ( `$options['featured-image-id']` or ‘$attachment_id’ ) into the actual view. The source code checks that `$options['featured-image-id’]` is set. If true, it returns the database value and assigns it to `$attachment_id`. 

In the unit test, I removed the empty data set, and ran a test assertion to check that the option value for 'featured-image-id' was set. It was ( returned true ). Yet, the test method processes the ternary operator and returns falsey ( 0 ). 

Resolving this issue is important. It will occur again when I attempt to write a unit test for the function `render_featured_image_id_field()` in the file: 

>`extend-give-wp/src/admin/option-settings-admin.php`. 

![renderFormFeaturedImage_unit_test_error_message_05-14-20](https://user-images.githubusercontent.com/3718603/81991192-43d19400-9606-11ea-86a3-61fcd5d9c655.png)

### Issues -- Integration Test

The most recent commits to the integration test file employed a different strategy. I used `add_option()` to add the option `extend-give-wp` to the database, and then used `get_option( `extend-give-wp`, [] )` to retrieve it. I then ran 2 test assertions to check that the both the option_name and the key=>value pair added to the option were set in memory ( they were ). That told me I could expect that the variable `$attachment_id` would be truthy and return the expected value ( it did ). 

My challenge is how to set or update a value on `$attachment[ 'post_excerpt' ]`. At present, the variable `$post_excerpt` returns falsey ( empty string ). I need to update the attachment object via the WordPress factory() method. I've attempted a couple of Core functions and methods and passing in a set of $args: 

- `wp_update_post()`, 
- `wp_insert_attachment()`,
- `$this->factory()->attachment->create_object( $args )`. 

Each fails to return an updated attachment or attachment object ( they return a value of 0 ). 
The result is that the variable `$post_excerpt` fails to load in the actual view file. 

![renderFormFeaturedImage_integration_test_error_messages_05-15-20](https://user-images.githubusercontent.com/3718603/82102491-5cf54600-96d5-11ea-9b5e-23e0f22792e3.png)


