### PR TITLE
PR#13 ( renderDonationLevelsLabel )

### DIFF
--- a/tests/phpunit/Integration/support/renderDonationLevelsLabel.php
+++ b/tests/phpunit/Integration/support/renderDonationLevelsLabel.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ *  Tests for render_donation_levels_label()
+ *
+ * @since      1.0.0
+ * @author     Robert A. Gadon
+ * @package    spiralWebDb\ExtendGiveWP\Tests\Integration
+ * @link       http://spiralwebdb.com
+ * @license    GNU General Public License 2.0+
+ */
+
+namespace spiralWebDb\ExtendGiveWP\Tests\Integration;
+
+use spiralWebDb\ExtendGiveWP\tests\phpunit\Integration\TestCase;
+use function spiralWebDb\ExtendGiveWP\get_give_donation_form_id;
+use function spiralWebDb\ExtendGiveWP\render_donation_levels_label;
+
+/**
+ * Class Tests_RenderDonationLevelsLabel
+ *
+ * @covers ::\spiralWebDb\ExtendGiveWP\render_donation_levels_label
+ *
+ * @group   extend-give-wp
+ * @group   support
+ *
+ * phpcs:disable Squiz.Commenting.FunctionComment.MissingParamTag
+ */
+class Tests_RenderDonationLevelsLabel extends TestCase {
+
+	/**
+	 *  Test should check callback registered to action hook has expected priority.
+	 */
+	public function test_callback_registered_to_action_hook_has_expected_priority() {
+		$this->assertEquals( 20, has_action( 'give_pre_form', 'spiralWebDb\ExtendGiveWP\render_donation_levels_label' ) );
+	}
+
+	/**
+	 * Test render_donation_levels_label() should render donation levels label given $form_id.
+	 *
+	 * @dataProvider addTestData
+	 */
+	public function test_should_render_donation_levels_label( $expected ) {
+		$form_id = $this->factory()->post->create();
+		$form_id = get_give_donation_form_id( $form_id );
+
+		ob_start();
+		render_donation_levels_label( $form_id );
+		$actual = ob_get_clean();
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 *  Data provider for unit test method.
+	 */
+	public function addTestData() {
+		return [
+			'donation levels label' => [
+				'expected_view' => <<<DONATION_LEVELS_LABEL_VIEW
+<div class="donation-levels-label-wrap">
+	<h3 class="donation-levels-label">Donation Amount</h3>
+	<p>Select the field to enter a custom amount, or choose a donation level below.</p>
+</div>
+
+DONATION_LEVELS_LABEL_VIEW
+				,
+			],
+		];
+	}
+}

--- a/tests/phpunit/Integration/support/renderDonationLevelsLabel.php
+++ b/tests/phpunit/Integration/support/renderDonationLevelsLabel.php
@@ -39,23 +39,29 @@ class Tests_RenderDonationLevelsLabel extends TestCase {
 	 *
 	 * @dataProvider addTestData
 	 */
-	public function test_should_render_donation_levels_label( $expected ) {
-		$form_id = $this->factory()->post->create();
+	public function test_should_render_donation_levels_label( $form_id, $expected_view ) {
 		$form_id = get_give_donation_form_id( $form_id );
 
 		ob_start();
 		render_donation_levels_label( $form_id );
-		$actual = ob_get_clean();
+		$actual_view = ob_get_clean();
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected_view, $actual_view );
 	}
 
 	/**
 	 *  Data provider for unit test method.
 	 */
 	public function addTestData() {
+		$form_id = $this->factory()->post->create();
+
 		return [
-			'donation levels label' => [
+			'donation levels label is empty' => [
+				'form_id'       => 0,
+				'expected_view' => '',
+			],
+			'donation levels label is valid' => [
+				'form_id'       => $form_id,
 				'expected_view' => <<<DONATION_LEVELS_LABEL_VIEW
 <div class="donation-levels-label-wrap">
 	<h3 class="donation-levels-label">Donation Amount</h3>

--- a/tests/phpunit/Unit/support/renderDonationLevelsLabel.php
+++ b/tests/phpunit/Unit/support/renderDonationLevelsLabel.php
@@ -42,10 +42,7 @@ class Tests_RenderDonationLevelsLabel extends TestCase {
 	 * @dataProvider addTestData
 	 */
 	public function test_should_render_donation_levels_label( $post_data, $expected ) {
-		Functions\expect( 'get_give_donation_form_id' )
-			->zeroOrMoreTimes()
-			->with( 'form_id' )
-			->andReturn( $post_data['form_id'] );
+		Functions\expect( 'get_give_donation_form_id' )->andReturn( $post_data['form_id'] );
 		Functions\expect( '_get_plugin_dir' )->andReturn( EXTEND_GIVE_WP_ROOT_DIR );
 
 		ob_start();

--- a/tests/phpunit/Unit/support/renderDonationLevelsLabel.php
+++ b/tests/phpunit/Unit/support/renderDonationLevelsLabel.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ *  Tests for render_donation_levels_label()
+ *
+ * @since      1.0.0
+ * @author     Robert A. Gadon
+ * @package    spiralWebDb\ExtendGiveWP\Tests\Unit
+ * @link       http://spiralwebdb.com
+ * @license    GNU General Public License 2.0+
+ */
+
+namespace spiralWebDb\ExtendGiveWP\Tests\Unit;
+
+use Brain\Monkey\Functions;
+use spiralWebDb\ExtendGiveWP\tests\phpunit\Unit\TestCase;
+use function spiralWebDb\ExtendGiveWP\render_donation_levels_label;
+
+/**
+ * Class Tests_RenderDonationLevelsLabel
+ *
+ * @covers ::\spiralWebDb\ExtendGiveWP\render_donation_levels_label
+ *
+ * @group   extend-give-wp
+ * @group   support
+ *
+ * phpcs:disable Squiz.Commenting.FunctionComment.MissingParamTag
+ */
+class Tests_RenderDonationLevelsLabel extends TestCase {
+
+	/**
+	 * Prepares the test environment before each test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		require_once EXTEND_GIVE_WP_ROOT_DIR . '/src/support/load-assets.php';
+	}
+
+	/**
+	 * Test render_donation_levels_label() should render donation levels label given $form_id.
+	 *
+	 * @dataProvider addTestData
+	 */
+	public function test_should_render_donation_levels_label( $post_data, $expected ) {
+		Functions\expect( 'get_give_donation_form_id' )
+			->zeroOrMoreTimes()
+			->with( 'form_id' )
+			->andReturn( $post_data['form_id'] );
+		Functions\expect( '_get_plugin_dir' )->andReturn( EXTEND_GIVE_WP_ROOT_DIR );
+
+		ob_start();
+		render_donation_levels_label( $post_data['form_id'] );
+		$actual = ob_get_clean();
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 *  Data provider for unit test method.
+	 */
+	public function addTestData() {
+		return [
+			'donation levels label' => [
+				'post_data'     => [
+					'form_id' => 42,
+				],
+				'expected_view' => <<<DONATION_LEVELS_LABEL_VIEW
+<div class="donation-levels-label-wrap">
+	<h3 class="donation-levels-label">Donation Amount</h3>
+	<p>Select the field to enter a custom amount, or choose a donation level below.</p>
+</div>
+
+DONATION_LEVELS_LABEL_VIEW
+				,
+			],
+		];
+	}
+}
+

--- a/tests/phpunit/Unit/support/renderDonationLevelsLabel.php
+++ b/tests/phpunit/Unit/support/renderDonationLevelsLabel.php
@@ -41,12 +41,12 @@ class Tests_RenderDonationLevelsLabel extends TestCase {
 	 *
 	 * @dataProvider addTestData
 	 */
-	public function test_should_render_donation_levels_label( $post_data, $expected ) {
-		Functions\expect( 'get_give_donation_form_id' )->andReturn( $post_data['form_id'] );
+	public function test_should_render_donation_levels_label( $form_id, $expected ) {
+		Functions\expect( 'get_give_donation_form_id' )->andReturn( $form_id );
 		Functions\expect( '_get_plugin_dir' )->andReturn( EXTEND_GIVE_WP_ROOT_DIR );
 
 		ob_start();
-		render_donation_levels_label( $post_data['form_id'] );
+		render_donation_levels_label( $form_id );
 		$actual = ob_get_clean();
 
 		$this->assertEquals( $expected, $actual );
@@ -57,10 +57,12 @@ class Tests_RenderDonationLevelsLabel extends TestCase {
 	 */
 	public function addTestData() {
 		return [
-			'donation levels label' => [
-				'post_data'     => [
-					'form_id' => 42,
-				],
+			'donation levels label is empty' => [
+				'form_id'       => 0,
+				'expected_view' => '',
+			],
+			'donation levels label is valid' => [
+				'form_id'       => 42,
 				'expected_view' => <<<DONATION_LEVELS_LABEL_VIEW
 <div class="donation-levels-label-wrap">
 	<h3 class="donation-levels-label">Donation Amount</h3>


### PR DESCRIPTION
## PR Summary 

This pull request includes unit and integration tests for the function `render_donation_levels_label()` in the `extend-give-wp` plugin. The relative file path to the function under test is:

>` extend-give-wp/src/support/load-assets.php`.