### PR TITLE
PR#14 ( calloutRecurringDonationOption )

### DIFF
--- a/tests/phpunit/Integration/support/calloutRecurringDonationOption.php
+++ b/tests/phpunit/Integration/support/calloutRecurringDonationOption.php
@@ -38,24 +38,30 @@ class Tests_CalloutRecurringDonationOption extends TestCase {
 	 *
 	 * @dataProvider addTestData
 	 */
-	public function test_should_render_recurring_donation_option_label( $expected ) {
-		$form_id = $this->factory()->post->create();
+	public function test_should_render_recurring_donation_option_label( $form_id, $expected_view ) {
 		$form_id = get_give_donation_form_id( $form_id );
 		$args    = [];
 
 		ob_start();
 		do_action( 'give_after_donation_levels', $form_id, $args );
-		$actual = ob_get_clean();
+		$actual_view = ob_get_clean();
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected_view, $actual_view );
 	}
 
 	/**
 	 *  Data provider for unit test method.
 	 */
 	public function addTestData() {
+		$form_id = $this->factory()->post->create();
+
 		return [
-			'donation view' => [
+			'donation levels label is empty' => [
+				'form_id'       => 0,
+				'expected_view' => '',
+			],
+			'donation levels label is valid' => [
+				'form_id'       => $form_id,
 				'expected_view' => <<<CALLOUT_RECURRING_DONATION_VIEW
 <h3 class="recurring-donation-callout">Make This a Recurring Gift?</h3>
 

--- a/tests/phpunit/Integration/support/calloutRecurringDonationOption.php
+++ b/tests/phpunit/Integration/support/calloutRecurringDonationOption.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ *  Tests for callout_recurring_donation_option()
+ *
+ * @since      1.0.0
+ * @author     Robert A. Gadon
+ * @package    spiralWebDb\ExtendGiveWP\Tests\Integration
+ * @link       http://spiralwebdb.com
+ * @license    GNU General Public License 2.0+
+ */
+
+namespace spiralWebDb\ExtendGiveWP\Tests\Integration;
+
+use spiralWebDb\ExtendGiveWP\tests\phpunit\Integration\TestCase;
+use function spiralWebDb\ExtendGiveWP\get_give_donation_form_id;
+
+/**
+ * Class Tests_CalloutRecurringDonationOption
+ *
+ * @covers ::\spiralWebDb\ExtendGiveWP\callout_recurring_donation_option
+ *
+ * @group   extend-give-wp
+ * @group   support
+ *
+ * phpcs:disable Squiz.Commenting.FunctionComment.MissingParamTag
+ */
+class Tests_CalloutRecurringDonationOption extends TestCase {
+
+	/**
+	 *  Test should check callback registered to action hook has expected priority.
+	 */
+	public function test_callback_registered_to_action_hook_has_expected_priority() {
+		$this->assertEquals( 1, has_action( 'give_after_donation_levels', 'spiralWebDb\ExtendGiveWP\callout_recurring_donation_option' ) );
+	}
+
+	/**
+	 * Test callout_recurring_donation_option() should render option label given $form_id.
+	 *
+	 * @dataProvider addTestData
+	 */
+	public function test_should_render_recurring_donation_option_label( $expected ) {
+		$form_id = $this->factory()->post->create();
+		$form_id = get_give_donation_form_id( $form_id );
+		$args    = [];
+
+		ob_start();
+		do_action( 'give_after_donation_levels', $form_id, $args );
+		$actual = ob_get_clean();
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 *  Data provider for unit test method.
+	 */
+	public function addTestData() {
+		return [
+			'donation view' => [
+				'expected_view' => <<<CALLOUT_RECURRING_DONATION_VIEW
+<h3 class="recurring-donation-callout">Make This a Recurring Gift?</h3>
+
+CALLOUT_RECURRING_DONATION_VIEW
+				,
+			],
+		];
+	}
+}
+

--- a/tests/phpunit/Unit/support/calloutRecurringDonationOption.php
+++ b/tests/phpunit/Unit/support/calloutRecurringDonationOption.php
@@ -49,7 +49,7 @@ class Tests_CalloutRecurringDonationOption extends TestCase {
 		Functions\expect( '_get_plugin_dir' )->andReturn( EXTEND_GIVE_WP_ROOT_DIR );
 
 		ob_start();
-		callout_recurring_donation_option( $form_id );
+		callout_recurring_donation_option( $post_data['form_id'] );
 		$actual = ob_get_clean();
 
 		$this->assertEquals( $expected, $actual );

--- a/tests/phpunit/Unit/support/calloutRecurringDonationOption.php
+++ b/tests/phpunit/Unit/support/calloutRecurringDonationOption.php
@@ -1,0 +1,74 @@
+<?php
+/**
+ *  Tests for callout_recurring_donation_option()
+ *
+ * @since      1.0.0
+ * @author     Robert A. Gadon
+ * @package    spiralWebDb\ExtendGiveWP\Tests\Unit
+ * @link       http://spiralwebdb.com
+ * @license    GNU General Public License 2.0+
+ */
+
+namespace spiralWebDb\ExtendGiveWP\Tests\Unit;
+
+use Brain\Monkey\Functions;
+use spiralWebDb\ExtendGiveWP\tests\phpunit\Unit\TestCase;
+use function spiralWebDb\ExtendGiveWP\get_give_donation_form_id;
+use function spiralWebDb\ExtendGiveWP\callout_recurring_donation_option;
+
+/**
+ * Class Tests_CalloutRecurringDonationOption
+ *
+ * @covers ::\spiralWebDb\ExtendGiveWP\callout_recurring_donation_option
+ *
+ * @group   extend-give-wp
+ * @group   support
+ *
+ * phpcs:disable Squiz.Commenting.FunctionComment.MissingParamTag
+ */
+class Tests_CalloutRecurringDonationOption extends TestCase {
+
+	/**
+	 * Prepares the test environment before each test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		require_once EXTEND_GIVE_WP_ROOT_DIR . '/src/support/load-assets.php';
+	}
+
+	/**
+	 * Test callout_recurring_donation_option() should render donation levels label given $form_id.
+	 *
+	 * @dataProvider addTestData
+	 */
+	public function test_should_render_recurring_donation_option_label( $post_data, $expected ) {
+		Functions\expect( 'get_give_donation_form_id' )->andReturn( $post_data['form_id'] );
+		Functions\expect( '_get_plugin_dir' )->andReturn( EXTEND_GIVE_WP_ROOT_DIR );
+
+		ob_start();
+		callout_recurring_donation_option( $form_id );
+		$actual = ob_get_clean();
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 *  Data provider for unit test method.
+	 */
+	public function addTestData() {
+		return [
+			'donation levels label' => [
+				'post_data'     => [
+					'form_id' => 17,
+				],
+				'expected_view' => <<<CALLOUT_RECURRING_DONATION_VIEW
+<h3 class="recurring-donation-callout">Make This a Recurring Gift?</h3>
+
+CALLOUT_RECURRING_DONATION_VIEW
+				,
+			],
+		];
+	}
+}
+

--- a/tests/phpunit/Unit/support/calloutRecurringDonationOption.php
+++ b/tests/phpunit/Unit/support/calloutRecurringDonationOption.php
@@ -13,7 +13,6 @@ namespace spiralWebDb\ExtendGiveWP\Tests\Unit;
 
 use Brain\Monkey\Functions;
 use spiralWebDb\ExtendGiveWP\tests\phpunit\Unit\TestCase;
-use function spiralWebDb\ExtendGiveWP\get_give_donation_form_id;
 use function spiralWebDb\ExtendGiveWP\callout_recurring_donation_option;
 
 /**

--- a/tests/phpunit/Unit/support/calloutRecurringDonationOption.php
+++ b/tests/phpunit/Unit/support/calloutRecurringDonationOption.php
@@ -41,18 +41,18 @@ class Tests_CalloutRecurringDonationOption extends TestCase {
 	 *
 	 * @dataProvider addTestData
 	 */
-	public function test_should_render_recurring_donation_option_label( $post_data, $expected ) {
+	public function test_should_render_recurring_donation_option_label( $form_id, $expected_view ) {
 		Functions\expect( 'get_give_donation_form_id' )
 			->zeroOrMoreTimes()
 			->with( 'form_id' )
-			->andReturn( $post_data['form_id'] );
+			->andReturn( $form_id );
 		Functions\expect( '_get_plugin_dir' )->andReturn( EXTEND_GIVE_WP_ROOT_DIR );
 
 		ob_start();
-		callout_recurring_donation_option( $post_data['form_id'] );
-		$actual = ob_get_clean();
+		callout_recurring_donation_option( $form_id );
+		$actual_view = ob_get_clean();
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected_view, $actual_view );
 	}
 
 	/**
@@ -60,10 +60,12 @@ class Tests_CalloutRecurringDonationOption extends TestCase {
 	 */
 	public function addTestData() {
 		return [
-			'donation levels label' => [
-				'post_data'     => [
-					'form_id' => 17,
-				],
+			'donation levels label is empty' => [
+				'form_id'       => 0,
+				'expected_view' => '',
+			],
+			'donation levels label is valid' => [
+				'form_id'       => 17,
 				'expected_view' => <<<CALLOUT_RECURRING_DONATION_VIEW
 <h3 class="recurring-donation-callout">Make This a Recurring Gift?</h3>
 

--- a/tests/phpunit/Unit/support/calloutRecurringDonationOption.php
+++ b/tests/phpunit/Unit/support/calloutRecurringDonationOption.php
@@ -42,7 +42,10 @@ class Tests_CalloutRecurringDonationOption extends TestCase {
 	 * @dataProvider addTestData
 	 */
 	public function test_should_render_recurring_donation_option_label( $post_data, $expected ) {
-		Functions\expect( 'get_give_donation_form_id' )->andReturn( $post_data['form_id'] );
+		Functions\expect( 'get_give_donation_form_id' )
+			->zeroOrMoreTimes()
+			->with( 'form_id' )
+			->andReturn( $post_data['form_id'] );
 		Functions\expect( '_get_plugin_dir' )->andReturn( EXTEND_GIVE_WP_ROOT_DIR );
 
 		ob_start();


### PR DESCRIPTION
## PR Summary 

This pull request includes unit and integration tests for the function `callout_recurring_donation_option()` in the `extend-give-wp` plugin. The relative file path to the function under test is:

>` extend-give-wp/src/support/load-assets.php`.