### PR TITLE
PR#15 ( renderPaymentMethodInfoBeforeOptions ) 

### DIFF
--- a/tests/phpunit/Integration/support/givePaymentModeBeforeGateways.php
+++ b/tests/phpunit/Integration/support/givePaymentModeBeforeGateways.php
@@ -1,0 +1,76 @@
+<?php
+/**
+ *  Tests for render_payment_method_info_before_options()
+ *
+ * @since      1.0.0
+ * @author     Robert A. Gadon
+ * @package    spiralWebDb\ExtendGiveWP\Tests\Integration
+ * @link       http://spiralwebdb.com
+ * @license    GNU General Public License 2.0+
+ */
+
+namespace spiralWebDb\ExtendGiveWP\Tests\Integration;
+
+use spiralWebDb\ExtendGiveWP\tests\phpunit\Integration\TestCase;
+use function spiralWebDb\ExtendGiveWP\get_give_donation_form_id;
+
+/**
+ * Class Tests_RenderPaymentMethodInfoBeforeOptions
+ *
+ * @covers ::\spiralWebDb\ExtendGiveWP\render_payment_method_info_before_options
+ *
+ * @group   extend-give-wp
+ * @group   support
+ *
+ * phpcs:disable Squiz.Commenting.FunctionComment.MissingParamTag
+ */
+class Tests_RenderPaymentMethodInfoBeforeOptions extends TestCase {
+
+	/**
+	 *  Test should check callback registered to action hook has expected priority.
+	 */
+	public function test_callback_registered_to_action_hook_has_expected_priority() {
+		$this->assertEquals( 10, has_action( 'give_payment_mode_before_gateways', 'spiralWebDb\ExtendGiveWP\render_payment_method_info_before_options' ) );
+	}
+
+	/**
+	 * Test render_payment_method_info_before_options() should render option label given $form_id.
+	 *
+	 * @dataProvider addTestData
+	 */
+	public function test_should_render_recurring_donation_option_label( $expected ) {
+		$form_id = $this->factory()->post->create();
+		$form_id = get_give_donation_form_id( $form_id );
+		$args    = [];
+
+		ob_start();
+		do_action( 'give_payment_mode_before_gateways', $form_id, $args );
+		$actual = ob_get_clean();
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 *  Data provider for unit test method.
+	 */
+	public function addTestData() {
+		return [
+			'payment info view' => [
+				'expected_view' => <<<PAYMENT_INFO_VIEW
+<div class="donation-form-display-content-before-payment-options">
+	<p>Extend your donation, and reduce the cost to Cornerstone of processing your gift.  Payment options include:</p>
+	<ol>
+		<li><strong><em>Credit card</em></strong> — pay the transaction fees by clicking the checkbox above; <strong>OR</strong></li>
+		<li><strong><em>Bank Account</em></strong> - donate directly from your bank account. Fees are typically less than 1%, with a cap of $5.00; <strong>OR</strong></li>
+		<li><strong><em>Offline Donation</em></strong> - make a pledge by completing the form. Please follow the directions below to fulfill your pledge.
+		</li>
+	</ol>
+</div>
+
+PAYMENT_INFO_VIEW
+				,
+			],
+		];
+	}
+}
+

--- a/tests/phpunit/Integration/support/givePaymentModeBeforeGateways.php
+++ b/tests/phpunit/Integration/support/givePaymentModeBeforeGateways.php
@@ -12,7 +12,6 @@
 namespace spiralWebDb\ExtendGiveWP\Tests\Integration;
 
 use spiralWebDb\ExtendGiveWP\tests\phpunit\Integration\TestCase;
-use function spiralWebDb\ExtendGiveWP\get_give_donation_form_id;
 
 /**
  * Class Tests_RenderPaymentMethodInfoBeforeOptions
@@ -38,16 +37,13 @@ class Tests_RenderPaymentMethodInfoBeforeOptions extends TestCase {
 	 *
 	 * @dataProvider addTestData
 	 */
-	public function test_should_render_recurring_donation_option_label( $expected ) {
-		$form_id = $this->factory()->post->create();
-		$form_id = get_give_donation_form_id( $form_id );
-		$args    = [];
+	public function test_should_render_recurring_donation_option_label( $expected_view ) {
 
 		ob_start();
-		do_action( 'give_payment_mode_before_gateways', $form_id, $args );
-		$actual = ob_get_clean();
+		do_action( 'give_payment_mode_before_gateways' );
+		$actual_view = ob_get_clean();
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected_view, $actual_view );
 	}
 
 	/**
@@ -55,7 +51,7 @@ class Tests_RenderPaymentMethodInfoBeforeOptions extends TestCase {
 	 */
 	public function addTestData() {
 		return [
-			'payment info view' => [
+			'payment info label is valid' => [
 				'expected_view' => <<<PAYMENT_INFO_VIEW
 <div class="donation-form-display-content-before-payment-options">
 	<p>Extend your donation, and reduce the cost to Cornerstone of processing your gift.  Payment options include:</p>

--- a/tests/phpunit/Unit/support/givePaymentModeBeforeGateways.php
+++ b/tests/phpunit/Unit/support/givePaymentModeBeforeGateways.php
@@ -1,0 +1,84 @@
+<?php
+/**
+ *  Tests for render_payment_method_info_before_options()
+ *
+ * @since      1.0.0
+ * @author     Robert A. Gadon
+ * @package    spiralWebDb\ExtendGiveWP\Tests\Unit
+ * @link       http://spiralwebdb.com
+ * @license    GNU General Public License 2.0+
+ */
+
+namespace spiralWebDb\ExtendGiveWP\Tests\Unit;
+
+use Brain\Monkey\Functions;
+use spiralWebDb\ExtendGiveWP\tests\phpunit\Unit\TestCase;
+use function spiralWebDb\ExtendGiveWP\render_payment_method_info_before_options;
+
+/**
+ * Class Tests_RenderPaymentMethodInfoBeforeOptions
+ *
+ * @covers ::\spiralWebDb\ExtendGiveWP\render_payment_method_info_before_options
+ *
+ * @group   extend-give-wp
+ * @group   support
+ *
+ * phpcs:disable Squiz.Commenting.FunctionComment.MissingParamTag
+ */
+class Tests_RenderPaymentMethodInfoBeforeOptions extends TestCase {
+
+	/**
+	 * Prepares the test environment before each test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		require_once EXTEND_GIVE_WP_ROOT_DIR . '/src/support/load-assets.php';
+	}
+
+	/**
+	 * Test render_payment_method_info_before_options() should render donation levels label given $form_id.
+	 *
+	 * @dataProvider addTestData
+	 */
+	public function test_should_render_recurring_donation_option_label( $post_data, $expected ) {
+		Functions\expect( 'get_give_donation_form_id' )
+			->zeroOrMoreTimes()
+			->with( 'form_id' )
+			->andReturn( $post_data['form_id'] );
+		Functions\expect( '_get_plugin_dir' )->andReturn( EXTEND_GIVE_WP_ROOT_DIR );
+
+		ob_start();
+		render_payment_method_info_before_options( $post_data['form_id'] );
+		$actual = ob_get_clean();
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 *  Data provider for unit test method.
+	 */
+	public function addTestData() {
+		return [
+			'payment info view' => [
+				'post_data'     => [
+					'form_id' => 26,
+				],
+				'expected_view' => <<<PAYMENT_INFO_VIEW
+<div class="donation-form-display-content-before-payment-options">
+	<p>Extend your donation, and reduce the cost to Cornerstone of processing your gift.  Payment options include:</p>
+	<ol>
+		<li><strong><em>Credit card</em></strong> — pay the transaction fees by clicking the checkbox above; <strong>OR</strong></li>
+		<li><strong><em>Bank Account</em></strong> - donate directly from your bank account. Fees are typically less than 1%, with a cap of $5.00; <strong>OR</strong></li>
+		<li><strong><em>Offline Donation</em></strong> - make a pledge by completing the form. Please follow the directions below to fulfill your pledge.
+		</li>
+	</ol>
+</div>
+
+PAYMENT_INFO_VIEW
+				,
+			],
+		];
+	}
+}
+

--- a/tests/phpunit/Unit/support/givePaymentModeBeforeGateways.php
+++ b/tests/phpunit/Unit/support/givePaymentModeBeforeGateways.php
@@ -41,18 +41,14 @@ class Tests_RenderPaymentMethodInfoBeforeOptions extends TestCase {
 	 *
 	 * @dataProvider addTestData
 	 */
-	public function test_should_render_recurring_donation_option_label( $post_data, $expected ) {
-		Functions\expect( 'get_give_donation_form_id' )
-			->zeroOrMoreTimes()
-			->with( 'form_id' )
-			->andReturn( $post_data['form_id'] );
+	public function test_should_render_recurring_donation_option_label( $expected_view ) {
 		Functions\expect( '_get_plugin_dir' )->andReturn( EXTEND_GIVE_WP_ROOT_DIR );
 
 		ob_start();
-		render_payment_method_info_before_options( $post_data['form_id'] );
-		$actual = ob_get_clean();
+		render_payment_method_info_before_options();
+		$actual_view = ob_get_clean();
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected_view, $actual_view );
 	}
 
 	/**
@@ -60,11 +56,8 @@ class Tests_RenderPaymentMethodInfoBeforeOptions extends TestCase {
 	 */
 	public function addTestData() {
 		return [
-			'payment info view' => [
-				'post_data'     => [
-					'form_id' => 26,
-				],
-				'expected_view' => <<<PAYMENT_INFO_VIEW
+			'payment info label'           => [
+				'expected_view' => <<<PAYMENT_INFO_LABEL
 <div class="donation-form-display-content-before-payment-options">
 	<p>Extend your donation, and reduce the cost to Cornerstone of processing your gift.  Payment options include:</p>
 	<ol>
@@ -75,7 +68,7 @@ class Tests_RenderPaymentMethodInfoBeforeOptions extends TestCase {
 	</ol>
 </div>
 
-PAYMENT_INFO_VIEW
+PAYMENT_INFO_LABEL
 				,
 			],
 		];

--- a/tests/phpunit/Unit/support/givePaymentModeBeforeGateways.php
+++ b/tests/phpunit/Unit/support/givePaymentModeBeforeGateways.php
@@ -56,7 +56,7 @@ class Tests_RenderPaymentMethodInfoBeforeOptions extends TestCase {
 	 */
 	public function addTestData() {
 		return [
-			'payment info label'           => [
+			'payment info label' => [
 				'expected_view' => <<<PAYMENT_INFO_LABEL
 <div class="donation-form-display-content-before-payment-options">
 	<p>Extend your donation, and reduce the cost to Cornerstone of processing your gift.  Payment options include:</p>


### PR DESCRIPTION
## PR Summary

This pull request includes unit and integration tests for the function `render_payment_method_info_before_options()` in the `extend-give-wp` plugin. The relative file path to the function under test is:

>`/extend-give-wp/src/support/load-assets.php`.

**Note:** The action event to which the function under test is registered does not pass any parameters (e.g. `$form_id` ). Any registered callback that passes an HTML view file cannot be integration tested for a scenario where both the `$form_id` and `$expected_view` are empty. 