### PR TITLE
PR#16 ( renderNewsletterSignupCallout )

### DIFF
--- a/tests/phpunit/Integration/support/renderNewsletterSignupCallout.php
+++ b/tests/phpunit/Integration/support/renderNewsletterSignupCallout.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ *  Tests for render_newsletter_signup_callout()
+ *
+ * @since      1.0.0
+ * @author     Robert A. Gadon
+ * @package    spiralWebDb\ExtendGiveWP\Tests\Integration
+ * @link       http://spiralwebdb.com
+ * @license    GNU General Public License 2.0+
+ */
+
+namespace spiralWebDb\ExtendGiveWP\Tests\Integration;
+
+use spiralWebDb\ExtendGiveWP\tests\phpunit\Integration\TestCase;
+use function spiralWebDb\ExtendGiveWP\get_give_donation_form_id;
+
+/**
+ * Class Test_RenderNewsletterSignupCallout
+ *
+ * @covers ::\spiralWebDb\ExtendGiveWP\render_newsletter_signup_callout
+ *
+ * @group   extend-give-wp
+ * @group   support
+ *
+ * phpcs:disable Squiz.Commenting.FunctionComment.MissingParamTag
+ */
+class Test_RenderNewsletterSignupCallout extends TestCase {
+
+	/**
+	 *  Test should check callback registered to action hook has expected priority.
+	 */
+	public function test_callback_registered_to_action_hook_has_expected_priority() {
+		$this->assertEquals( 10, has_action( 'give_payment_mode_before_gateways', 'spiralWebDb\ExtendGiveWP\render_payment_method_info_before_options' ) );
+	}
+
+	/**
+	 * Test render_payment_method_info_before_options() should render option label given $form_id.
+	 *
+	 * @dataProvider addTestData
+	 */
+	public function test_should_render_recurring_donation_option_label( $expected ) {
+		$form_id = $this->factory()->post->create();
+		$form_id = get_give_donation_form_id( $form_id );
+		$args    = [];
+
+		ob_start();
+		do_action( 'give_donation_form_before_submit', $form_id, $args );
+		$actual = ob_get_clean();
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 *  Data provider for unit test method.
+	 */
+	public function addTestData() {
+		return [
+			'payment info view' => [
+				'expected_view' => <<<NEWSLETTER_CALLOUT_VIEW
+<h3 id="give-form-5-1" class="newsletter-callout">Cornerstone Newsletter</h3>
+
+NEWSLETTER_CALLOUT_VIEW
+				,
+			],
+		];
+	}
+}
+

--- a/tests/phpunit/Integration/support/renderNewsletterSignupCallout.php
+++ b/tests/phpunit/Integration/support/renderNewsletterSignupCallout.php
@@ -38,26 +38,32 @@ class Test_RenderNewsletterSignupCallout extends TestCase {
 	 *
 	 * @dataProvider addTestData
 	 */
-	public function test_should_render_recurring_donation_option_label( $expected ) {
-		$form_id = $this->factory()->post->create();
+	public function test_should_render_recurring_donation_option_label( $form_id, $expected_view ) {
 		$form_id = get_give_donation_form_id( $form_id );
 		$args    = [];
 
 		ob_start();
 		do_action( 'give_donation_form_before_submit', $form_id, $args );
-		$actual = ob_get_clean();
+		$actual_view = ob_get_clean();
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected_view, $actual_view );
 	}
 
 	/**
 	 *  Data provider for unit test method.
 	 */
 	public function addTestData() {
+		$form_id = $this->factory()->post->create();
+
 		return [
-			'payment info view' => [
+			'test data is empty' => [
+				'form_id'       => '',
+				'expected_view' => '',
+			],
+			'test data is valid' => [
+				'form_id'       => $form_id,
 				'expected_view' => <<<NEWSLETTER_CALLOUT_VIEW
-<h3 id="give-form-5-1" class="newsletter-callout">Cornerstone Newsletter</h3>
+<h3 id="give-form-4-1" class="newsletter-callout">Cornerstone Newsletter</h3>
 
 NEWSLETTER_CALLOUT_VIEW
 				,

--- a/tests/phpunit/Unit/support/renderNewsletterSignupCallout.php
+++ b/tests/phpunit/Unit/support/renderNewsletterSignupCallout.php
@@ -49,7 +49,7 @@ class Test_RenderNewsletterSignupCallout extends TestCase {
 			->with( 'form_id' )
 			->andReturn( $form_id );
 		Functions\expect( '_get_plugin_dir' )->andReturn( EXTEND_GIVE_WP_ROOT_DIR );
-		
+
 		ob_start();
 		render_newsletter_signup_callout( $form_id );
 		$actual_view = ob_get_clean();

--- a/tests/phpunit/Unit/support/renderNewsletterSignupCallout.php
+++ b/tests/phpunit/Unit/support/renderNewsletterSignupCallout.php
@@ -47,7 +47,7 @@ class Test_RenderNewsletterSignupCallout extends TestCase {
 			->with( 'form_id' )
 			->andReturn( $post_data['form_id'] );
 		Functions\expect( '_get_plugin_dir' )->andReturn( EXTEND_GIVE_WP_ROOT_DIR );
-		Functions\when( 'esc_attr' )->justEcho( $post_data['form_id'] );
+		Functions\when( 'esc_attr' )->justReturn( $post_data['form_id'] );
 
 		ob_start();
 		render_newsletter_signup_callout( $post_data['form_id'] );

--- a/tests/phpunit/Unit/support/renderNewsletterSignupCallout.php
+++ b/tests/phpunit/Unit/support/renderNewsletterSignupCallout.php
@@ -33,6 +33,8 @@ class Test_RenderNewsletterSignupCallout extends TestCase {
 	public function setUp() {
 		parent::setUp();
 
+		$this->setup_common_wp_stubs();
+
 		require_once EXTEND_GIVE_WP_ROOT_DIR . '/src/support/load-assets.php';
 	}
 
@@ -47,8 +49,7 @@ class Test_RenderNewsletterSignupCallout extends TestCase {
 			->with( 'form_id' )
 			->andReturn( $form_id );
 		Functions\expect( '_get_plugin_dir' )->andReturn( EXTEND_GIVE_WP_ROOT_DIR );
-		Functions\when( 'esc_attr' )->justReturn( $form_id );
-
+		
 		ob_start();
 		render_newsletter_signup_callout( $form_id );
 		$actual_view = ob_get_clean();

--- a/tests/phpunit/Unit/support/renderNewsletterSignupCallout.php
+++ b/tests/phpunit/Unit/support/renderNewsletterSignupCallout.php
@@ -41,19 +41,19 @@ class Test_RenderNewsletterSignupCallout extends TestCase {
 	 *
 	 * @dataProvider addTestData
 	 */
-	public function test_should_render_recurring_donation_option_label( $post_data, $expected ) {
+	public function test_should_render_recurring_donation_option_label( $form_id, $expected_view ) {
 		Functions\expect( 'get_give_donation_form_id' )
 			->zeroOrMoreTimes()
 			->with( 'form_id' )
-			->andReturn( $post_data['form_id'] );
+			->andReturn( $form_id );
 		Functions\expect( '_get_plugin_dir' )->andReturn( EXTEND_GIVE_WP_ROOT_DIR );
-		Functions\when( 'esc_attr' )->justReturn( $post_data['form_id'] );
+		Functions\when( 'esc_attr' )->justReturn( $form_id );
 
 		ob_start();
-		render_newsletter_signup_callout( $post_data['form_id'] );
-		$actual = ob_get_clean();
+		render_newsletter_signup_callout( $form_id );
+		$actual_view = ob_get_clean();
 
-		$this->assertEquals( $expected, $actual );
+		$this->assertEquals( $expected_view, $actual_view );
 	}
 
 	/**
@@ -61,10 +61,12 @@ class Test_RenderNewsletterSignupCallout extends TestCase {
 	 */
 	public function addTestData() {
 		return [
-			'newsletter callout view' => [
-				'post_data'     => [
-					'form_id' => 33,
-				],
+			'test data is empty' => [
+				'form_id'       => '',
+				'expected_view' => '',
+			],
+			'test data is valid' => [
+				'form_id'       => 33,
 				'expected_view' => <<<NEWSLETTER_CALLOUT_VIEW
 <h3 id="give-form-33-1" class="newsletter-callout">Cornerstone Newsletter</h3>
 

--- a/tests/phpunit/Unit/support/renderNewsletterSignupCallout.php
+++ b/tests/phpunit/Unit/support/renderNewsletterSignupCallout.php
@@ -1,0 +1,77 @@
+<?php
+/**
+ *  Tests for render_newsletter_signup_callout()
+ *
+ * @since      1.0.0
+ * @author     Robert A. Gadon
+ * @package    spiralWebDb\ExtendGiveWP\Tests\Unit
+ * @link       http://spiralwebdb.com
+ * @license    GNU General Public License 2.0+
+ */
+
+namespace spiralWebDb\ExtendGiveWP\Tests\Unit;
+
+use Brain\Monkey\Functions;
+use spiralWebDb\ExtendGiveWP\tests\phpunit\Unit\TestCase;
+use function spiralWebDb\ExtendGiveWP\render_newsletter_signup_callout;
+
+/**
+ * Class Test_RenderNewsletterSignupCallout
+ *
+ * @covers ::\spiralWebDb\ExtendGiveWP\render_newsletter_signup_callout
+ *
+ * @group   extend-give-wp
+ * @group   support
+ *
+ * phpcs:disable Squiz.Commenting.FunctionComment.MissingParamTag
+ */
+class Test_RenderNewsletterSignupCallout extends TestCase {
+
+	/**
+	 * Prepares the test environment before each test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		require_once EXTEND_GIVE_WP_ROOT_DIR . '/src/support/load-assets.php';
+	}
+
+	/**
+	 * Test render_newsletter_signup_callout() should render donation levels label given $form_id.
+	 *
+	 * @dataProvider addTestData
+	 */
+	public function test_should_render_recurring_donation_option_label( $post_data, $expected ) {
+		Functions\expect( 'get_give_donation_form_id' )
+			->zeroOrMoreTimes()
+			->with( 'form_id' )
+			->andReturn( $post_data['form_id'] );
+		Functions\expect( '_get_plugin_dir' )->andReturn( EXTEND_GIVE_WP_ROOT_DIR );
+		Functions\when( 'esc_attr' )->justEcho( $post_data['form_id'] );
+
+		ob_start();
+		render_newsletter_signup_callout( $post_data['form_id'] );
+		$actual = ob_get_clean();
+
+		$this->assertEquals( $expected, $actual );
+	}
+
+	/**
+	 *  Data provider for unit test method.
+	 */
+	public function addTestData() {
+		return [
+			'newsletter callout view' => [
+				'post_data'     => [
+					'form_id' => 33,
+				],
+				'expected_view' => <<<NEWSLETTER_CALLOUT_VIEW
+<h3 id="give-form-33-1" class="newsletter-callout">Cornerstone Newsletter</h3>
+
+NEWSLETTER_CALLOUT_VIEW
+				,
+			],
+		];
+	}
+}
+


### PR DESCRIPTION
## PR Summary 

This pull request includes unit and integration tests for the function `render_newsletter_signup_callout()` in the `extend-give-wp` plugin. The relative file path to the function under test is:

>`/extend-give-wp/src/support/load-assets.php`.