### PR TITLE
[WIP]PR#18 ( addOptionSettingsPage )

### DIFF
--- a/src/admin/option-settings-admin.php
+++ b/src/admin/option-settings-admin.php
@@ -20,7 +20,7 @@ add_action( 'admin_menu', __NAMESPACE__ . '\add_option_settings_page' );
  * @since 1.0.0
  */
 function add_option_settings_page() {
-	add_submenu_page(
+	$hookname = add_submenu_page(
 		'options-general.php',  // parent slug.
 		'Extend GiveWP -- Donation Form Option Settings', // page title.
 		'Extend GiveWP', // menu title.
@@ -28,6 +28,8 @@ function add_option_settings_page() {
 		'extend-give-wp', // menu slug.
 		__NAMESPACE__ . '\render_option_page_template' // callback to output page content.
 	);
+
+	return $hookname;
 }
 
 /**
@@ -47,9 +49,9 @@ add_action( 'admin_init', __NAMESPACE__ . '\initialize_option_settings' );
 /**
  * Initialize settings on the option settings admin page.
  *
+ * @return void
  * @since 1.0.0
  *
- * @return void
  */
 function initialize_option_settings() {
 	register_setting( 'extend-give-wp', 'extend-give-wp' );

--- a/src/admin/option-settings-admin.php
+++ b/src/admin/option-settings-admin.php
@@ -51,7 +51,6 @@ add_action( 'admin_init', __NAMESPACE__ . '\initialize_option_settings' );
  *
  * @return void
  * @since 1.0.0
- *
  */
 function initialize_option_settings() {
 	register_setting( 'extend-give-wp', 'extend-give-wp' );

--- a/tests/phpunit/Integration/admin/addOptionSettingsPage.php
+++ b/tests/phpunit/Integration/admin/addOptionSettingsPage.php
@@ -53,10 +53,6 @@ class Tests_AddOptionSettingsPage extends TestCase {
 		do_action( 'admin_menu', '' );
 
 		var_dump( add_option_settings_page() );
-//      function 'add_submenu_page' should return $hookname on success.
-//		$hookname = 'settings_page_extend-give-wp';
-
-//      Note: Either invoking do_action( 'admin_menu', '' ) or the function under test returns falsey (null or '' ).
 	}
 }
 

--- a/tests/phpunit/Integration/admin/addOptionSettingsPage.php
+++ b/tests/phpunit/Integration/admin/addOptionSettingsPage.php
@@ -1,0 +1,59 @@
+<?php
+/**
+ *  Tests for add_option_settings_page()
+ *
+ * @since      1.0.0
+ * @author     Robert A. Gadon
+ * @package    spiralWebDb\ExtendGiveWP\Tests\Integration
+ * @link       http://spiralwebdb.com
+ * @license    GNU General Public License 2.0+
+ */
+
+namespace spiralWebDb\ExtendGiveWP\Tests\Integration;
+
+use spiralWebDb\ExtendGiveWP\tests\phpunit\Integration\TestCase;
+use function spiralWebDb\ExtendGiveWP\Admin\add_option_settings_page;
+
+/**
+ * Class Tests_AddOptionSettingsPage
+ *
+ * @covers ::\spiralWebDb\ExtendGiveWP\add_option_settings_page
+ *
+ * @group   extend-give-wp
+ * @group   admin
+ *
+ * phpcs:disable Squiz.Commenting.FunctionComment.MissingParamTag
+ */
+class Tests_AddOptionSettingsPage extends TestCase {
+
+	/**
+	 *  Test should check callback registered to action hook has expected priority.
+	 */
+	public function test_callback_registered_to_action_hook_has_expected_priority() {
+		$this->assertEquals( 10, has_action( 'admin_menu', 'spiralWebDb\ExtendGiveWP\Admin\add_option_settings_page' ) );
+	}
+
+	/**
+	 * Test add_option_settings_page() should add option settings page to admin.
+	 */
+	public function test_should_add_option_settings_page_and_return_hookname() {
+		$post = $this->factory->post->create_and_get();
+
+		add_submenu_page(
+			'options-general.php',
+			'Extend GiveWP -- Donation Form Option Settings',
+			'Extend GiveWP',
+			'manage_categories',
+			'extend-give-wp',
+			'spiralWebDb\ExtendGiveWP\Admin\render_option_page_template'
+		); // returns false.
+
+		$this->go_to( 'http://example.org/wp-admin/options-general.php?page=extend-give-wp' );
+
+//      function 'add_submenu_page' should return $hookname on success.
+//		$hookname = 'settings_page_extend-give-wp';
+
+//      Note: Either invoking do_action( 'admin_menu', '' ) or the function under test returns falsey (null or '' ).
+	}
+}
+

--- a/tests/phpunit/Integration/admin/addOptionSettingsPage.php
+++ b/tests/phpunit/Integration/admin/addOptionSettingsPage.php
@@ -37,7 +37,9 @@ class Tests_AddOptionSettingsPage extends TestCase {
 	 * Test add_option_settings_page() should add option settings page to admin.
 	 */
 	public function test_should_add_option_settings_page_and_return_hookname() {
-		$user = $this->factory()->user->create_and_get( [ 'role' => 'administrator' ] );
+		// Add user with admin capability to access submenu admin page.
+		$user = $this->factory()->user->create_and_get( [ 'role' => 'editor' ] );
+		$post = $this->factory()->post->create_and_get();
 
 		$hookname = add_submenu_page(
 			'options-general.php',
@@ -47,12 +49,12 @@ class Tests_AddOptionSettingsPage extends TestCase {
 			'extend-give-wp',
 			'spiralWebDb\ExtendGiveWP\Admin\render_option_page_template'
 		);
-		var_dump( $hookname );
+
 		$this->go_to( 'http://example.org/wp-admin/options-general.php?page=extend-give-wp' );
 
 		do_action( 'admin_menu', '' );
-
-		var_dump( add_option_settings_page() );
+		var_dump( $hookname ); // false
+		var_dump( add_option_settings_page() ); // false
 	}
 }
 

--- a/tests/phpunit/Integration/admin/addOptionSettingsPage.php
+++ b/tests/phpunit/Integration/admin/addOptionSettingsPage.php
@@ -37,19 +37,22 @@ class Tests_AddOptionSettingsPage extends TestCase {
 	 * Test add_option_settings_page() should add option settings page to admin.
 	 */
 	public function test_should_add_option_settings_page_and_return_hookname() {
-		$post = $this->factory->post->create_and_get();
+		$user = $this->factory()->user->create_and_get( [ 'role' => 'administrator' ] );
 
-		add_submenu_page(
+		$hookname = add_submenu_page(
 			'options-general.php',
 			'Extend GiveWP -- Donation Form Option Settings',
 			'Extend GiveWP',
 			'manage_categories',
 			'extend-give-wp',
 			'spiralWebDb\ExtendGiveWP\Admin\render_option_page_template'
-		); // returns false.
-
+		);
+		var_dump( $hookname );
 		$this->go_to( 'http://example.org/wp-admin/options-general.php?page=extend-give-wp' );
 
+		do_action( 'admin_menu', '' );
+
+		var_dump( add_option_settings_page() );
 //      function 'add_submenu_page' should return $hookname on success.
 //		$hookname = 'settings_page_extend-give-wp';
 

--- a/tests/phpunit/Unit/admin/addOptionSettingsPage.php
+++ b/tests/phpunit/Unit/admin/addOptionSettingsPage.php
@@ -1,0 +1,60 @@
+<?php
+/**
+ *  Tests for add_option_settings_page()
+ *
+ * @since      1.0.0
+ * @author     Robert A. Gadon
+ * @package    spiralWebDb\ExtendGiveWP\Tests\Unit
+ * @link       http://spiralwebdb.com
+ * @license    GNU General Public License 2.0+
+ */
+
+namespace spiralWebDb\ExtendGiveWP\Tests\Unit;
+
+use Brain\Monkey\Functions;
+use spiralWebDb\ExtendGiveWP\tests\phpunit\Unit\TestCase;
+use function spiralWebDb\ExtendGiveWP\Admin\add_option_settings_page;
+
+/**
+ * Class Tests_AddOptionSettingsPage
+ *
+ * @covers ::\spiralWebDb\ExtendGiveWP\add_option_settings_page
+ *
+ * @group   extend-give-wp
+ * @group   admin
+ *
+ * phpcs:disable Squiz.Commenting.FunctionComment.MissingParamTag
+ */
+class Tests_AddOptionSettingsPage extends TestCase {
+
+	/**
+	 * Prepares the test environment before each test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		require_once EXTEND_GIVE_WP_ROOT_DIR . '/src/admin/option-settings-admin.php';
+	}
+
+	/**
+	 * Test add_option_settings_page() should add option settings page to admin.
+	 */
+	public function test_should_add_option_settings_page() {
+		$hookname = 'settings_page_extend-give-wp';
+
+		Functions\expect( 'add_submenu_page' )
+			->zeroOrMoreTimes()
+			->with(
+				'options-general.php',
+				'Extend GiveWP -- Donation Form Option Settings',
+				'Extend GiveWP',
+				'manage_categories',
+				'extend-give-wp',
+				'spiralWebDb\ExtendGiveWP\Admin\render_option_page_template'
+			)
+			->andReturn( 'settings_page_extend-give-wp' );
+
+		$this->assertNull( add_option_settings_page() );
+	}
+}
+

--- a/tests/phpunit/Unit/admin/addOptionSettingsPage.php
+++ b/tests/phpunit/Unit/admin/addOptionSettingsPage.php
@@ -40,10 +40,11 @@ class Tests_AddOptionSettingsPage extends TestCase {
 	 * Test add_option_settings_page() should add option settings page to admin.
 	 */
 	public function test_should_add_option_settings_page() {
+		// String returned by add_submenu_page() on success.
 		$hookname = 'settings_page_extend-give-wp';
 
 		Functions\expect( 'add_submenu_page' )
-			->zeroOrMoreTimes()
+			->once()
 			->with(
 				'options-general.php',
 				'Extend GiveWP -- Donation Form Option Settings',
@@ -52,9 +53,9 @@ class Tests_AddOptionSettingsPage extends TestCase {
 				'extend-give-wp',
 				'spiralWebDb\ExtendGiveWP\Admin\render_option_page_template'
 			)
-			->andReturn( 'settings_page_extend-give-wp' );
+			->andReturn( $hookname );
 
-		$this->assertNull( add_option_settings_page() );
+		$this->assertEquals( $hookname, add_option_settings_page() );
 	}
 }
 


### PR DESCRIPTION
## PR Summary 

This PR adds a unit and integration test for the function `add_option_settings_page()` in the `extend-give-wp` plugin. The function adds a submenu page to the WordPress admin at the url: 

>'/wp-admin/options-general.php?page=extend-give-wp'.

The relative file path to the function under test is: 

>`extend-give-wp/src/admin/option-settings-admin.php`.

===========================================
@hellofromtonya 

### What's known about the source code: 

- In it's original form, the function under test ( `add_option_settings_page()` )  returns void.  
- When `add_submenu_page()` successfully registers a submenu page, it returns the page’s hook suffix ( $hookname ). Otherwise, returns false if the user does not have the required capability to access the menu page.
- For the purposes of testing, I assigned the value of `add_submenu_page()` to the variable `$hookname`, and returned it's value back to the function. 


### Unit Test (test assertion passes)

- For the purpose of unit testing, I tested the assertion that the function `add_submenu_page()` successfully registered the submenu and returned the variable `$hookname`. _The test assertion passed._ 

### [WIP] Integration Test

- In the file `/wordpress-develop/tests/phpunit/tests/admin/includesPlugin.php`, I found the function `test_menu_page_url()` as a potential model to test that the $menu_slug ‘extend-give-wp’  ( passed as the 5th parameter to `add_submenu_page()` ) would return the menu page url. That attempt failed. 
- When I called `do_action( ‘admin_menu’, ‘’ );` I expected the action hook to fire, and the callback registered to it to return the value of `$hookname`. It returned an empty string instead. 
- I used `var_dump()` to inspect the value assigned to `$hookname` and `add_option_settings_page()`. Both returned false. 

I know that the action hook `‘admin_menu’` already fired, so I need to fire it again in the test method. The previous test involving `has_filter()` tells me that the callback `add_option_settings_page()` _IS_ registered to the event. 

Is there a timing issue as to why the callback does not return a value for `$hookname` when the action event is invoked again? 

The capability level set by  `add_submenu_page()` in the test method is 'manage_categories’. That requires a user assigned to at least an Editor role, which _was set_ in the factory for the user. So capability should not be a factor as to why `add_option_settings_page()` returns false. 