### PR TITLE
[WIP]PR#19 ( renderOptionPageTemplate )

### DIFF
--- a/tests/phpunit/Integration/admin/renderOptionPageTemplate.php
+++ b/tests/phpunit/Integration/admin/renderOptionPageTemplate.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ *  Tests for render_option_page_template()
+ *
+ * @since      1.0.0
+ * @author     Robert A. Gadon
+ * @package    spiralWebDb\ExtendGiveWP\Tests\Integration
+ * @link       http://spiralwebdb.com
+ * @license    GNU General Public License 2.0+
+ */
+
+namespace spiralWebDb\ExtendGiveWP\Tests\Integration;
+
+use spiralWebDb\ExtendGiveWP\tests\phpunit\Integration\TestCase;
+use function spiralWebDb\ExtendGiveWP\Admin\render_option_page_template;
+
+/**
+ * Class Test_RenderNewsletterSignupCallout
+ *
+ * @covers ::\spiralWebDb\ExtendGiveWP\render_option_page_template
+ *
+ * @group   extend-give-wp
+ * @group   admin
+ *
+ * phpcs:disable Squiz.Commenting.FunctionComment.MissingParamTag
+ */
+class Test_RenderOptionPageTemplate extends TestCase {
+
+	/**
+	 * Test render_option_page_template() should render template for current user.
+	 *
+	 * @dataProvider addTestData
+	 */
+	public function test_option_page_template_renders_for_current_user( $user_data, $expected_view ) {
+		$user = $this->factory()->user->create_and_get( $user_data );
+
+		do_action( 'admin_menu', '' );
+
+		$this->go_to( 'http://example.com//wp-admin/options-general.php?page=extend-give-wp' );
+
+		ob_start();
+		render_option_page_template();
+		$actual_view = ob_get_clean(); // returns falsey (empty string)
+
+		$this->assertEquals( $expected_view, $actual_view ); // assertion fails.
+	}
+
+	/**
+	 * Data generator for test method.
+	 */
+	public function addTestData() {
+		return [
+			'render option page template' => [
+				'user_data'     => [
+					'role' => 'editor',
+				],
+				'expected_view' => <<< OPTION_PAGE_TEMPLATE
+<div class="wrap">
+	<h1>Extend GiveWP -- Donation Form Option Settings</h1>
+	<form action="options.php" method="post">
+							</form>
+</div>
+
+OPTION_PAGE_TEMPLATE
+				,
+			]
+		];
+	}
+}
+

--- a/tests/phpunit/Integration/admin/renderOptionPageTemplate.php
+++ b/tests/phpunit/Integration/admin/renderOptionPageTemplate.php
@@ -63,7 +63,7 @@ class Test_RenderOptionPageTemplate extends TestCase {
 
 OPTION_PAGE_TEMPLATE
 				,
-			]
+			],
 		];
 	}
 }

--- a/tests/phpunit/Unit/admin/renderOptionPageTemplate.php
+++ b/tests/phpunit/Unit/admin/renderOptionPageTemplate.php
@@ -1,0 +1,93 @@
+<?php
+/**
+ *  Tests for render_option_page_template()
+ *
+ * @since      1.0.0
+ * @author     Robert A. Gadon
+ * @package    spiralWebDb\ExtendGiveWP\Tests\Unit
+ * @link       http://spiralwebdb.com
+ * @license    GNU General Public License 2.0+
+ */
+
+namespace spiralWebDb\ExtendGiveWP\Tests\Unit;
+
+use Brain\Monkey\Functions;
+use spiralWebDb\ExtendGiveWP\tests\phpunit\Unit\TestCase;
+use function spiralWebDb\ExtendGiveWP\Admin\render_option_page_template;
+
+/**
+ * Class Test_RenderOptionPageTemplate
+ *
+ * @covers ::\spiralWebDb\ExtendGiveWP\render_option_page_template
+ *
+ * @group   extend-give-wp
+ * @group   admin
+ *
+ * phpcs:disable Squiz.Commenting.FunctionComment.MissingParamTag
+ */
+class Test_RenderOptionPageTemplate extends TestCase {
+
+	/**
+	 * Prepares the test environment before each test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->setup_common_wp_stubs();
+
+		require_once EXTEND_GIVE_WP_ROOT_DIR . '/src/admin/option-settings-admin.php';
+	}
+
+	/**
+	 * Test render_option_page_template() should render template for current user.
+	 *
+	 * @dataProvider addTestData
+	 */
+	public function test_option_page_template_renders_for_current_user( $title, $expected_view ) {
+		Functions\expect( 'current_user_can' )
+			->once()
+			->with( 'manage_categories' )
+			->andReturn( true );
+		Functions\expect( 'get_admin_page_title' )->andReturn( $title );
+		Functions\expect( 'settings_fields' )
+			->once()
+			->with( 'extend-give-wp' )
+			->andReturnNull();
+		Functions\expect( 'do_settings_sections' )
+			->once()
+			->with( 'extend-give-wp' )
+			->andReturnNull();
+		Functions\expect( 'submit_button' )
+			->once()
+			->with( 'Save Settings', 'primary' )
+			->andReturnNull();
+		Functions\expect( 'spiralWebDb\ExtendGiveWP\_get_plugin_dir' )->andReturn( EXTEND_GIVE_WP_ROOT_DIR );
+
+		ob_start();
+		render_option_page_template();
+		$actual_view = ob_get_clean();
+
+		$this->assertEquals( $expected_view, $actual_view );
+	}
+
+	/**
+	 * Data provider for test method.
+	 */
+	public function addTestData() {
+		return [
+			'render option page template' => [
+				'expected_title' => 'Extend GiveWP -- Donation Form Option Settings',
+				'expected_view'  => <<< OPTION_PAGE_TEMPLATE
+<div class="wrap">
+	<h1>Extend GiveWP -- Donation Form Option Settings</h1>
+	<form action="options.php" method="post">
+							</form>
+</div>
+
+OPTION_PAGE_TEMPLATE
+				,
+			]
+		];
+	}
+}
+

--- a/tests/phpunit/Unit/admin/renderOptionPageTemplate.php
+++ b/tests/phpunit/Unit/admin/renderOptionPageTemplate.php
@@ -86,7 +86,7 @@ class Test_RenderOptionPageTemplate extends TestCase {
 
 OPTION_PAGE_TEMPLATE
 				,
-			]
+			],
 		];
 	}
 }


### PR DESCRIPTION
## PR Summary

This PR adds a unit and integration test for the function `render_option_page_template()` in the `extend-give-wp` plugin. The callback is the 6th parameter passed to `add_submenu_page()` within the function `add_option_settings_page()`. The function under test outputs the plugin's option page template in the WordPress admin at:  `/wp-admin/options-general.php?page=extend-give-wp`.

The relative file path within the plugin to the function under test is: 

>`extend-give-wp/src/admin/option-settings-admin.php`.

### Issues -- Integration Test

The assertion ( `assertEquals()` ) within the integration test method fails. 

The function under test is invoked from within the function `add_option_settings_page()` when the `admin_menu` action event files. 

While building the integration test method, I inspected the value of `(has_filter( ‘admin_menu’, ‘spiralWebDb\ExtendGiveWP\Admin\add_option_settings_page’)`. It returns the priority level of the callback registered to the event. 

I called `do_action( ‘admin_menu’, ‘’ );` within the test method, with the intent of invoking `add_option_settings_page()`, and then invoking `render_option_page_template()`. I then ran `render_option_page_template()` through the output buffer to return the actual view from the buffer. The buffer returned falsey ( empty string ). 

At present, the integration test is work-in-progress [WIP]. 