### PR TITLE
PR#20 ( initializeOptionSettings )

### DIFF
--- a/tests/phpunit/Integration/admin/initializeOptionSettings.php
+++ b/tests/phpunit/Integration/admin/initializeOptionSettings.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ *  Tests for initialize_option_settings()
+ *
+ * @since      1.0.0
+ * @author     Robert A. Gadon
+ * @package    spiralWebDb\ExtendGiveWP\Tests\Integration
+ * @link       http://spiralwebdb.com
+ * @license    GNU General Public License 2.0+
+ */
+
+namespace spiralWebDb\ExtendGiveWP\Tests\Integration;
+
+use spiralWebDb\ExtendGiveWP\tests\phpunit\Integration\TestCase;
+use function spiralWebDb\ExtendGiveWP\Admin\initialize_option_settings;
+
+/**
+ * Class Test_InitializeOptionSettings
+ *
+ * @covers ::\spiralWebDb\ExtendGiveWP\initialize_option_settings
+ *
+ * @group   extend-give-wp
+ * @group   admin
+ *
+ * phpcs:disable Squiz.Commenting.FunctionComment.MissingParamTag
+ */
+class Test_InitializeOptionSettings extends TestCase {
+
+}

--- a/tests/phpunit/Integration/admin/initializeOptionSettings.php
+++ b/tests/phpunit/Integration/admin/initializeOptionSettings.php
@@ -26,7 +26,7 @@ use function spiralWebDb\ExtendGiveWP\Admin\initialize_option_settings;
  */
 class Test_InitializeOptionSettings extends TestCase {
 
-	/*
+	/**
 	 * Test initialize_option_settings() is registered to the 'admin_init' hook and returns the expected priority.
 	 */
 	public function test_callback_is_registered_to_action_event_and_returns_expected_priority() {

--- a/tests/phpunit/Integration/admin/initializeOptionSettings.php
+++ b/tests/phpunit/Integration/admin/initializeOptionSettings.php
@@ -17,7 +17,7 @@ use function spiralWebDb\ExtendGiveWP\Admin\initialize_option_settings;
 /**
  * Class Test_InitializeOptionSettings
  *
- * @covers ::\spiralWebDb\ExtendGiveWP\initialize_option_settings
+ * @covers ::\spiralWebDb\ExtendGiveWP\Admin\initialize_option_settings
  *
  * @group   extend-give-wp
  * @group   admin
@@ -26,4 +26,18 @@ use function spiralWebDb\ExtendGiveWP\Admin\initialize_option_settings;
  */
 class Test_InitializeOptionSettings extends TestCase {
 
+	/*
+	 * Test initialize_option_settings() is registered to the 'admin_init' hook and returns the expected priority.
+	 */
+	public function test_callback_is_registered_to_action_event_and_returns_expected_priority() {
+		$this->assertEquals( 10, has_action( 'admin_init', 'spiralWebDb\ExtendGiveWP\Admin\initialize_option_settings' ) );
+	}
+
+	/**
+	 * Test initialize_option_settings() initializes option settings.
+	 */
+	public function test_function_initializes_options_settings() {
+		$this->assertNull( initialize_option_settings() );
+	}
 }
+

--- a/tests/phpunit/Unit/admin/initializeOptionSettings.php
+++ b/tests/phpunit/Unit/admin/initializeOptionSettings.php
@@ -18,7 +18,7 @@ use function spiralWebDb\ExtendGiveWP\Admin\initialize_option_settings;
 /**
  * Class Test_RenderOptionPageTemplate
  *
- * @covers ::\spiralWebDb\ExtendGiveWP\initialize_option_settings
+ * @covers ::\spiralWebDb\ExtendGiveWP\Admin\initialize_option_settings
  *
  * @group   extend-give-wp
  * @group   admin
@@ -35,4 +35,40 @@ class Test_RenderOptionPageTemplate extends TestCase {
 
 		require_once EXTEND_GIVE_WP_ROOT_DIR . '/src/admin/option-settings-admin.php';
 	}
+
+	/**
+	 * Test initialize_option_settings() initializes option settings.
+	 */
+	public function test_function_initializes_options_settings() {
+		Functions\expect( 'register_setting' )
+			->once()
+			->with( 'extend-give-wp', 'extend-give-wp' )
+			->andReturnNull();
+		Functions\expect( 'add_settings_section' )
+			->once()
+			->with(
+				'featured-image-section',
+				'Featured Image',
+				'spiralWebDb\ExtendGiveWP\Admin\render_featured_image_section_label',
+				'extend-give-wp'
+			)
+			->andReturnNull();
+		Functions\expect( 'add_settings_field' )
+			->once()
+			->with(
+				'featured-image-id',
+				'Featured Image ID',
+				'spiralWebDb\ExtendGiveWP\Admin\render_featured_image_id_field',
+				'extend-give-wp',
+				'featured-image-section',
+				[
+					'label_for' => 'featured-image-id',
+					'class'     => 'featured-image-id',
+				]
+			)
+			->andReturnNull();
+
+		$this->assertNull( initialize_option_settings() );
+	}
 }
+

--- a/tests/phpunit/Unit/admin/initializeOptionSettings.php
+++ b/tests/phpunit/Unit/admin/initializeOptionSettings.php
@@ -1,0 +1,38 @@
+<?php
+/**
+ *  Tests for initialize_option_settings()
+ *
+ * @since      1.0.0
+ * @author     Robert A. Gadon
+ * @package    spiralWebDb\ExtendGiveWP\Tests\Unit
+ * @link       http://spiralwebdb.com
+ * @license    GNU General Public License 2.0+
+ */
+
+namespace spiralWebDb\ExtendGiveWP\Tests\Unit;
+
+use Brain\Monkey\Functions;
+use spiralWebDb\ExtendGiveWP\tests\phpunit\Unit\TestCase;
+use function spiralWebDb\ExtendGiveWP\Admin\initialize_option_settings;
+
+/**
+ * Class Test_RenderOptionPageTemplate
+ *
+ * @covers ::\spiralWebDb\ExtendGiveWP\initialize_option_settings
+ *
+ * @group   extend-give-wp
+ * @group   admin
+ *
+ * phpcs:disable Squiz.Commenting.FunctionComment.MissingParamTag
+ */
+class Test_RenderOptionPageTemplate extends TestCase {
+
+	/**
+	 * Prepares the test environment before each test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		require_once EXTEND_GIVE_WP_ROOT_DIR . '/src/admin/option-settings-admin.php';
+	}
+}


### PR DESCRIPTION
## PR Summary

This PR adds a unit and integration test for the function `initialize_option_settings()` in the `extend-give-wp` plugin. The callback: 

- registers a setting, 
- adds a featured image settings section, and 
- adds a featured image ID settings field. 

The function returns `void`. 

The relative file path within the plugin to the function under test is: 

>`extend-give-wp/src/admin/option-settings-admin.php`.