### PR TITLE
PR#21 ( renderFeaturedImageSectionLabel )

### DIFF
--- a/tests/phpunit/Integration/admin/renderFeaturedImageSectionLabel.php
+++ b/tests/phpunit/Integration/admin/renderFeaturedImageSectionLabel.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ *  Tests for render_featured_image_section_label()
+ *
+ * @since      1.0.0
+ * @author     Robert A. Gadon
+ * @package    spiralWebDb\ExtendGiveWP\Tests\Integration
+ * @link       http://spiralwebdb.com
+ * @license    GNU General Public License 2.0+
+ */
+
+namespace spiralWebDb\ExtendGiveWP\Tests\Integration;
+
+use spiralWebDb\ExtendGiveWP\tests\phpunit\Integration\TestCase;
+use function spiralWebDb\ExtendGiveWP\Admin\render_featured_image_section_label;
+
+/**
+ * Class Test_RenderFeaturedImageSectionLabel
+ *
+ * @covers ::\spiralWebDb\ExtendGiveWP\render_featured_image_section_label
+ *
+ * @group   extend-give-wp
+ * @group   admin
+ *
+ * phpcs:disable Squiz.Commenting.FunctionComment.MissingParamTag
+ */
+class Test_RenderFeaturedImageSectionLabel extends TestCase {
+	
+}

--- a/tests/phpunit/Integration/admin/renderFeaturedImageSectionLabel.php
+++ b/tests/phpunit/Integration/admin/renderFeaturedImageSectionLabel.php
@@ -26,4 +26,18 @@ use function spiralWebDb\ExtendGiveWP\Admin\render_featured_image_section_label;
  */
 class Test_RenderFeaturedImageSectionLabel extends TestCase {
 
+	/*
+ * Test render_featured_image_section_label() should render featured image section view file.
+ */
+	public function test_should_render_featured_image_section_label() {
+		$expected_view = <<<FEATURED_IMAGE_SECTION_LABEL
+<p class="description">The featured image settings for the donation form.</p>
+
+FEATURED_IMAGE_SECTION_LABEL;
+
+		ob_start();
+		render_featured_image_section_label();
+		$this->assertEquals( $expected_view, ob_get_clean() );
+	}
 }
+

--- a/tests/phpunit/Integration/admin/renderFeaturedImageSectionLabel.php
+++ b/tests/phpunit/Integration/admin/renderFeaturedImageSectionLabel.php
@@ -26,9 +26,9 @@ use function spiralWebDb\ExtendGiveWP\Admin\render_featured_image_section_label;
  */
 class Test_RenderFeaturedImageSectionLabel extends TestCase {
 
-	/*
- * Test render_featured_image_section_label() should render featured image section view file.
- */
+	/**
+	 * Test render_featured_image_section_label() should render featured image section view file.
+	 */
 	public function test_should_render_featured_image_section_label() {
 		$expected_view = <<<FEATURED_IMAGE_SECTION_LABEL
 <p class="description">The featured image settings for the donation form.</p>

--- a/tests/phpunit/Integration/admin/renderFeaturedImageSectionLabel.php
+++ b/tests/phpunit/Integration/admin/renderFeaturedImageSectionLabel.php
@@ -17,7 +17,7 @@ use function spiralWebDb\ExtendGiveWP\Admin\render_featured_image_section_label;
 /**
  * Class Test_RenderFeaturedImageSectionLabel
  *
- * @covers ::\spiralWebDb\ExtendGiveWP\render_featured_image_section_label
+ * @covers ::\spiralWebDb\ExtendGiveWP\Admin\render_featured_image_section_label
  *
  * @group   extend-give-wp
  * @group   admin
@@ -25,5 +25,5 @@ use function spiralWebDb\ExtendGiveWP\Admin\render_featured_image_section_label;
  * phpcs:disable Squiz.Commenting.FunctionComment.MissingParamTag
  */
 class Test_RenderFeaturedImageSectionLabel extends TestCase {
-	
+
 }

--- a/tests/phpunit/Unit/admin/renderFeaturedImageSectionLabel.php
+++ b/tests/phpunit/Unit/admin/renderFeaturedImageSectionLabel.php
@@ -18,7 +18,7 @@ use function spiralWebDb\ExtendGiveWP\Admin\render_featured_image_section_label;
 /**
  * Class Test_RenderFeaturedImageSectionLabel
  *
- * @covers ::\spiralWebDb\ExtendGiveWP\render_featured_image_section_label
+ * @covers ::\spiralWebDb\ExtendGiveWP\Admin\render_featured_image_section_label
  *
  * @group   extend-give-wp
  * @group   admin

--- a/tests/phpunit/Unit/admin/renderFeaturedImageSectionLabel.php
+++ b/tests/phpunit/Unit/admin/renderFeaturedImageSectionLabel.php
@@ -35,3 +35,19 @@ class Test_RenderFeaturedImageSectionLabel extends TestCase {
 
 		require_once EXTEND_GIVE_WP_ROOT_DIR . '/src/admin/option-settings-admin.php';
 	}
+
+	/*
+	 * Test render_featured_image_section_label() should render featured image section view file.
+	 */
+	public function test_should_render_featured_image_section_label() {
+		Functions\expect( 'spiralWebDb\ExtendGiveWP\_get_plugin_dir' )->andReturn( EXTEND_GIVE_WP_ROOT_DIR );
+		$expected_view = <<<FEATURED_IMAGE_SECTION_LABEL
+<p class="description">The featured image settings for the donation form.</p>
+
+FEATURED_IMAGE_SECTION_LABEL;
+
+		ob_start();
+		render_featured_image_section_label();
+		$this->assertEquals( $expected_view, ob_get_clean() );
+	}
+}

--- a/tests/phpunit/Unit/admin/renderFeaturedImageSectionLabel.php
+++ b/tests/phpunit/Unit/admin/renderFeaturedImageSectionLabel.php
@@ -1,0 +1,37 @@
+<?php
+/**
+ *  Tests for render_featured_image_section_label()
+ *
+ * @since      1.0.0
+ * @author     Robert A. Gadon
+ * @package    spiralWebDb\ExtendGiveWP\Tests\Unit
+ * @link       http://spiralwebdb.com
+ * @license    GNU General Public License 2.0+
+ */
+
+namespace spiralWebDb\ExtendGiveWP\Tests\Unit;
+
+use Brain\Monkey\Functions;
+use spiralWebDb\ExtendGiveWP\tests\phpunit\Unit\TestCase;
+use function spiralWebDb\ExtendGiveWP\Admin\render_featured_image_section_label;
+
+/**
+ * Class Test_RenderFeaturedImageSectionLabel
+ *
+ * @covers ::\spiralWebDb\ExtendGiveWP\render_featured_image_section_label
+ *
+ * @group   extend-give-wp
+ * @group   admin
+ *
+ * phpcs:disable Squiz.Commenting.FunctionComment.MissingParamTag
+ */
+class Test_RenderFeaturedImageSectionLabel extends TestCase {
+
+	/**
+	 * Prepares the test environment before each test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		require_once EXTEND_GIVE_WP_ROOT_DIR . '/src/admin/option-settings-admin.php';
+	}

--- a/tests/phpunit/Unit/admin/renderFeaturedImageSectionLabel.php
+++ b/tests/phpunit/Unit/admin/renderFeaturedImageSectionLabel.php
@@ -36,7 +36,7 @@ class Test_RenderFeaturedImageSectionLabel extends TestCase {
 		require_once EXTEND_GIVE_WP_ROOT_DIR . '/src/admin/option-settings-admin.php';
 	}
 
-	/*
+	/**
 	 * Test render_featured_image_section_label() should render featured image section view file.
 	 */
 	public function test_should_render_featured_image_section_label() {


### PR DESCRIPTION
## PR Summary

This PR adds a unit and integration test for the function `render_featured_image_section_label()` in the `extend-give-wp` plugin. The callback is registered to WordPress from within the plugin function `initialize_option_settings()`. The function renders an HTML view file as part of the Featured Image settings section. It returns `void`. 

The relative file path within the plugin to the function under test is: 

>`extend-give-wp/src/admin/option-settings-admin.php`.