### PR TITLE
[WIP]PR#22 ( renderFeaturedImageIDField )

### DIFF
--- a/src/admin/option-settings-admin.php
+++ b/src/admin/option-settings-admin.php
@@ -93,11 +93,15 @@ function render_featured_image_section_label() {
 /**
  * Callback to render the settings field markup.
  *
- * @since 1.0.0
+ * @since 1.0.1
  */
 function render_featured_image_id_field() {
 	$options       = get_option( 'extend-give-wp', [] );
 	$attachment_id = isset( $options['featured-image-id'] ) ? (int) $options['featured-image-id'] : 0;
 
-	require_once _get_plugin_dir() . '/src/admin/views/featured-image-id-field.php';
+	if ( empty( $attachment_id ) ) {
+		return;
+	}
+
+	require _get_plugin_dir() . '/src/admin/views/featured-image-id-field.php';
 }

--- a/tests/phpunit/Integration/admin/renderFeaturedImageIDField.php
+++ b/tests/phpunit/Integration/admin/renderFeaturedImageIDField.php
@@ -25,8 +25,10 @@ use function spiralWebDb\ExtendGiveWP\Admin\render_featured_image_id_field;
  * phpcs:disable Squiz.Commenting.FunctionComment.MissingParamTag
  */
 class Test_RenderFeaturedImageIDField extends TestCase {
-	
+
 	/**
+	 * Test render_featured_image_id_field() should render featured image ID field.
+	 *
 	 * @dataProvider addTestData
 	 */
 	public function test_should_render_featured_image_id_field( $option, $expected_view ) {
@@ -40,11 +42,14 @@ class Test_RenderFeaturedImageIDField extends TestCase {
 		$this->assertEquals( $expected_view, $actual_view );
 	}
 
+	/**
+	 * Data provider for test method.
+	 */
 	public function addTestData() {
 		return [
 			'empty data set'     => [
 				'option_data'   => [
-					'featured-image-id' => 0
+					'featured-image-id' => 0,
 				],
 				'expected_view' => '',
 			],
@@ -62,7 +67,7 @@ class Test_RenderFeaturedImageIDField extends TestCase {
 
 FEATURED_IMAGE_ID_FIELD
 				,
-			]
+			],
 		];
 	}
 }

--- a/tests/phpunit/Integration/admin/renderFeaturedImageIDField.php
+++ b/tests/phpunit/Integration/admin/renderFeaturedImageIDField.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ *  Tests for render_featured_image_id_field()
+ *
+ * @since      1.0.0
+ * @author     Robert A. Gadon
+ * @package    spiralWebDb\ExtendGiveWP\Tests\Integration
+ * @link       http://spiralwebdb.com
+ * @license    GNU General Public License 2.0+
+ */
+
+namespace spiralWebDb\ExtendGiveWP\Tests\Integration;
+
+use spiralWebDb\ExtendGiveWP\tests\phpunit\Integration\TestCase;
+use function spiralWebDb\ExtendGiveWP\Admin\render_featured_image_id_field;
+
+/**
+ * Class Test_RenderFeaturedImageIDField
+ *
+ * @covers ::\spiralWebDb\ExtendGiveWP\Admin\render_featured_image_id_field
+ *
+ * @group   extend-give-wp
+ * @group   admin
+ *
+ * phpcs:disable Squiz.Commenting.FunctionComment.MissingParamTag
+ */
+class Test_RenderFeaturedImageIDField extends TestCase {
+
+}

--- a/tests/phpunit/Integration/admin/renderFeaturedImageIDField.php
+++ b/tests/phpunit/Integration/admin/renderFeaturedImageIDField.php
@@ -25,5 +25,45 @@ use function spiralWebDb\ExtendGiveWP\Admin\render_featured_image_id_field;
  * phpcs:disable Squiz.Commenting.FunctionComment.MissingParamTag
  */
 class Test_RenderFeaturedImageIDField extends TestCase {
+	
+	/**
+	 * @dataProvider addTestData
+	 */
+	public function test_should_render_featured_image_id_field( $option, $expected_view ) {
+		$options       = get_option( 'extend-give-wp', $option );
+		$attachment_id = isset( $option['featured-image-id'] ) ? (int) $option['featured-image-id'] : 0;
 
+		ob_start();
+		render_featured_image_id_field();
+		$actual_view = ob_get_clean();
+
+		$this->assertEquals( $expected_view, $actual_view );
+	}
+
+	public function addTestData() {
+		return [
+			'empty data set'     => [
+				'option_data'   => [
+					'featured-image-id' => 0
+				],
+				'expected_view' => '',
+			],
+			'non-empty data set' => [
+				'option_data'   => [
+					'featured-image-id' => 144,
+				],
+				'expected_view' => <<<FEATURED_IMAGE_ID_FIELD
+<label>
+	<input id="featured-image-id" class="normal-text" name="extend-give-wp[featured-image-id]" type="number" min="1" aria-describedby="featured-image-attachment-id" value="144">
+	<p id="featured-image-input-label" class="description">Enter the image ID for the donation form featured image in the field above.</p>
+	<p id="featured-image-input-label" class="description">Get the ID by opening the Media Library, and select the featured image.</p>
+	<p id="featured-image-input-label" class="description">View the permalink on the ‘Attachment Details’ page. The ID is the value of the ‘?item=‘ parameter in the permalink.</p>
+</label>
+
+FEATURED_IMAGE_ID_FIELD
+				,
+			]
+		];
+	}
 }
+

--- a/tests/phpunit/Unit/admin/renderFeaturedImageIDField.php
+++ b/tests/phpunit/Unit/admin/renderFeaturedImageIDField.php
@@ -1,0 +1,40 @@
+<?php
+/**
+ *  Tests for render_featured_image_id_field()
+ *
+ * @since      1.0.0
+ * @author     Robert A. Gadon
+ * @package    spiralWebDb\ExtendGiveWP\Tests\Unit
+ * @link       http://spiralwebdb.com
+ * @license    GNU General Public License 2.0+
+ */
+
+namespace spiralWebDb\ExtendGiveWP\Tests\Unit;
+
+use Brain\Monkey\Functions;
+use spiralWebDb\ExtendGiveWP\tests\phpunit\Unit\TestCase;
+use function spiralWebDb\ExtendGiveWP\Admin\render_featured_image_id_field;
+
+/**
+ * Class Test_RenderFeaturedImageIDField
+ *
+ * @covers ::\spiralWebDb\ExtendGiveWP\Admin\render_featured_image_id_field
+ *
+ * @group   extend-give-wp
+ * @group   admin
+ *
+ * phpcs:disable Squiz.Commenting.FunctionComment.MissingParamTag
+ */
+class Test_RenderFeaturedImageIDField extends TestCase {
+
+	/**
+	 * Prepares the test environment before each test.
+	 */
+	public function setUp() {
+		parent::setUp();
+
+		$this->setup_common_wp_stubs();
+
+		require_once EXTEND_GIVE_WP_ROOT_DIR . '/src/admin/option-settings-admin.php';
+	}
+}

--- a/tests/phpunit/Unit/admin/renderFeaturedImageIDField.php
+++ b/tests/phpunit/Unit/admin/renderFeaturedImageIDField.php
@@ -37,4 +37,48 @@ class Test_RenderFeaturedImageIDField extends TestCase {
 
 		require_once EXTEND_GIVE_WP_ROOT_DIR . '/src/admin/option-settings-admin.php';
 	}
+	
+	/**
+	 * @dataProvider addTestData
+	 */
+	public function test_should_render_featured_image_id_field( $option, $expected_view ) {
+		Functions\expect( 'get_option' )
+			->once()
+			->with( 'extend-give-wp', [] )
+			->andReturn( $option['featured-image-id'] );
+		Functions\expect( 'spiralWebDb\ExtendGiveWP\_get_plugin_dir' )->andReturn( EXTEND_GIVE_WP_ROOT_DIR );
+
+		ob_start();
+		render_featured_image_id_field();
+		$actual_view = ob_get_clean();
+
+		$this->assertEquals( $expected_view, $actual_view );
+	}
+
+	public function addTestData() {
+		return [
+			'empty data set'     => [
+				'option_data'   => [
+					'featured-image-id' => 0
+				],
+				'expected_view' => '',
+			],
+			'non-empty data set' => [
+				'option_data'   => [
+					'featured-image-id' => 144,
+				],
+				'expected_view' => <<<FEATURED_IMAGE_ID_FIELD
+<label>
+	<input id="featured-image-id" class="normal-text" name="extend-give-wp[featured-image-id]" type="number" min="1" aria-describedby="featured-image-attachment-id" value="144">
+	<p id="featured-image-input-label" class="description">Enter the image ID for the donation form featured image in the field above.</p>
+	<p id="featured-image-input-label" class="description">Get the ID by opening the Media Library, and select the featured image.</p>
+	<p id="featured-image-input-label" class="description">View the permalink on the ‘Attachment Details’ page. The ID is the value of the ‘?item=‘ parameter in the permalink.</p>
+</label>
+
+FEATURED_IMAGE_ID_FIELD
+				,
+			]
+		];
+	}
 }
+

--- a/tests/phpunit/Unit/admin/renderFeaturedImageIDField.php
+++ b/tests/phpunit/Unit/admin/renderFeaturedImageIDField.php
@@ -37,8 +37,10 @@ class Test_RenderFeaturedImageIDField extends TestCase {
 
 		require_once EXTEND_GIVE_WP_ROOT_DIR . '/src/admin/option-settings-admin.php';
 	}
-	
+
 	/**
+	 * Test render_featured_image_id_field() should render featured image ID field.
+	 *
 	 * @dataProvider addTestData
 	 */
 	public function test_should_render_featured_image_id_field( $option, $expected_view ) {
@@ -55,11 +57,14 @@ class Test_RenderFeaturedImageIDField extends TestCase {
 		$this->assertEquals( $expected_view, $actual_view );
 	}
 
+	/**
+	 * Data provider for test method.
+	 */
 	public function addTestData() {
 		return [
 			'empty data set'     => [
 				'option_data'   => [
-					'featured-image-id' => 0
+					'featured-image-id' => 0,
 				],
 				'expected_view' => '',
 			],
@@ -77,7 +82,7 @@ class Test_RenderFeaturedImageIDField extends TestCase {
 
 FEATURED_IMAGE_ID_FIELD
 				,
-			]
+			],
 		];
 	}
 }


### PR DESCRIPTION
## PR Summary

This PR adds a unit and integration test for the function `render_featured_image_id_field()` in the `extend-give-wp` plugin. The callback is registered to WordPress from within the plugin function `initialize_option_settings()`. The function renders an HTML view file as part of the Featured Image ID settings field. It returns `void`. 

The relative file path within the plugin to the function under test is: 

>`extend-give-wp/src/admin/option-settings-admin.php`.

============================================

@hellofromtonya 

### Issues - Unit

The test method runs 2 test scenarios. 

Scenario 1: ‘featured-image-id’ => 0, and ‘expected_view’ => ‘’.
Scenario 2: ‘featured-image-id’ => 144, and ‘expected_view’ => <<<HMTL_VIEW.

The source code gets the option value, assigns it to a variable, and then conditionally checks that the variable is set. If no, then return 0. 

I added a guardrail condition to the source code that if the variable is falsey ( 0 ), return early. 

In the second test scenario, the actual HTML view file is falsey (returns empty string). 

`function render_featured_image_id_field()  {`
	`$options       = get_option( 'extend-give-wp', [] );`
	`$attachment_id = isset( $options['featured-image-id'] ) ? (int) $options['featured-image-id'] : 0;`

Inside the unit test, I ran the following test assertion (which I did not commit). 

>// The parameter originates from the test method's dataProvider.
>`$this->assertTrue( isset( $option['featured-image-id'] ) ); // passes. 

This is a similar issue to PR#11. 

### Issues - Integration

Same as the unit test above. 